### PR TITLE
format with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+IndentWidth: 4

--- a/.nix/rdss.nix
+++ b/.nix/rdss.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cmake
+{ stdenv, lib, cmake, clang-tools
 , abseil-cpp, gtest, z3, highway, rapidcheck
 }:
 
@@ -13,5 +13,5 @@ stdenv.mkDerivation {
 
   buildInputs = [ abseil-cpp gtest highway rapidcheck z3 ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake clang-tools ];
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,3 +54,9 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(fhd_tests)
+
+file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.hpp)
+add_custom_target(
+    clangformat
+    COMMAND clang-format -style=LLVM -i ${ALL_SOURCE_FILES}
+)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -22,51 +22,48 @@
 
 namespace rdss {
 
-std::string Member::ToCpp(FreshVariableSource* source) const {
-    return absl::StrFormat("%s %s;\n", this->type->ToCpp(), this->name.ToCpp());
+std::string Member::ToCpp(FreshVariableSource *source) const {
+  return absl::StrFormat("%s %s;\n", this->type->ToCpp(), this->name.ToCpp());
 }
 
 // <type> <name>(<arg1>, <arg2>, ..., <argN>)
-std::string Method::ToCpp(FreshVariableSource* source) const {
-    std::vector<std::string> args_vec;
-    for (int32_t i = 0; i < this->arguments.size(); i++) {
-        args_vec.push_back(absl::StrCat(
-                               this->arguments[i].second->ToCpp(),
-                               " ",
-                               this->arguments[i].first.ToCpp()));
-    }
+std::string Method::ToCpp(FreshVariableSource *source) const {
+  std::vector<std::string> args_vec;
+  for (int32_t i = 0; i < this->arguments.size(); i++) {
+    args_vec.push_back(absl::StrCat(this->arguments[i].second->ToCpp(), " ",
+                                    this->arguments[i].first.ToCpp()));
+  }
 
-    auto args = absl::StrJoin(args_vec, ", ");
+  auto args = absl::StrJoin(args_vec, ", ");
 
-    std::string body;
-    for (int32_t i = 0; i < this->body.size(); i++) {
-        absl::StrAppend(&body, Indent(this->body[i]->ToCpp(source), 1), "\n");
-    }
+  std::string body;
+  for (int32_t i = 0; i < this->body.size(); i++) {
+    absl::StrAppend(&body, Indent(this->body[i]->ToCpp(source), 1), "\n");
+  }
 
-    return absl::StrFormat("void %s(%s) {\n%s}",
-                           this->name.ToCpp(), args, body);
+  return absl::StrFormat("void %s(%s) {\n%s}", this->name.ToCpp(), args, body);
 }
 
-std::string DataStructure::ToCpp(FreshVariableSource* source) const {
-    std::stringstream ss;
-    if (!this->type_parameters.empty()) {
-        ss << "template<";
-        std::vector<std::string> params;
-        for (const auto& ty_param : this->type_parameters) {
-            params.push_back("typename " + ty_param.ToCpp());
-        }
-        ss << absl::StrJoin(params, ", ");
-        ss << ">\n";
+std::string DataStructure::ToCpp(FreshVariableSource *source) const {
+  std::stringstream ss;
+  if (!this->type_parameters.empty()) {
+    ss << "template<";
+    std::vector<std::string> params;
+    for (const auto &ty_param : this->type_parameters) {
+      params.push_back("typename " + ty_param.ToCpp());
     }
-    ss << "struct " << this->name << " {\n";
-    for (const auto& member : this->members) {
-        ss << Indent(member.ToCpp(source), 1);
-    }
-    for (const auto& method : this->methods) {
-        ss << Indent(method.ToCpp(source), 1);
-    }
-    ss << "}\n";
-    return ss.str();
+    ss << absl::StrJoin(params, ", ");
+    ss << ">\n";
+  }
+  ss << "struct " << this->name << " {\n";
+  for (const auto &member : this->members) {
+    ss << Indent(member.ToCpp(source), 1);
+  }
+  for (const auto &method : this->methods) {
+    ss << Indent(method.ToCpp(source), 1);
+  }
+  ss << "}\n";
+  return ss.str();
 }
 
-}  // namespace rdss
+} // namespace rdss

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -40,513 +40,470 @@ using Attr = int32_t;
 using AttrPermutation = std::vector<Attr>;
 using AttrPartialPermutation = std::vector<absl::optional<Attr>>;
 
-template<typename T>
-struct Viewed {
-    AttrPartialPermutation perm;
-    T rel;
+template <typename T> struct Viewed {
+  AttrPartialPermutation perm;
+  T rel;
 
-    Viewed(const T& rel_) : rel(rel_), perm() {
-        for (int32_t i = 0; i < rel_->Arity(); i++) {
-            perm.push_back(i);
-        }
+  Viewed(const T &rel_) : rel(rel_), perm() {
+    for (int32_t i = 0; i < rel_->Arity(); i++) {
+      perm.push_back(i);
     }
+  }
 
-    Viewed(const AttrPartialPermutation& perm_, const T& rel_)
-        : rel(rel_), perm(perm_) {}
+  Viewed(const AttrPartialPermutation &perm_, const T &rel_)
+      : rel(rel_), perm(perm_) {}
 
-    std::string ToString() const {
-        std::vector<std::string> strings;
-        for (const auto& attr_maybe : perm) {
-            if (attr_maybe.has_value()) {
-                strings.push_back(absl::StrFormat("%d", attr_maybe.value()));
-            } else {
-                strings.push_back("ø");
-            }
-        }
-        std::string perm_string =
-            absl::StrFormat("[%s]", absl::StrJoin(strings, ", "));
-        if (Viewed(rel).perm == perm) {
-            return rel->ToString();
-        }
-        return absl::StrFormat("Viewed(%s, %s)", perm_string, rel->ToString());
+  std::string ToString() const {
+    std::vector<std::string> strings;
+    for (const auto &attr_maybe : perm) {
+      if (attr_maybe.has_value()) {
+        strings.push_back(absl::StrFormat("%d", attr_maybe.value()));
+      } else {
+        strings.push_back("ø");
+      }
     }
-
-    int32_t Arity() const {
-        int32_t result = 0;
-        for (const auto& attr_maybe : perm) {
-            if (attr_maybe.has_value()) {
-                result++;
-            }
-        }
-        return result;
+    std::string perm_string =
+        absl::StrFormat("[%s]", absl::StrJoin(strings, ", "));
+    if (Viewed(rel).perm == perm) {
+      return rel->ToString();
     }
+    return absl::StrFormat("Viewed(%s, %s)", perm_string, rel->ToString());
+  }
+
+  int32_t Arity() const {
+    int32_t result = 0;
+    for (const auto &attr_maybe : perm) {
+      if (attr_maybe.has_value()) {
+        result++;
+      }
+    }
+    return result;
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Function {
-    std::string name;
-    int32_t arguments;
-    int32_t results;
+  std::string name;
+  int32_t arguments;
+  int32_t results;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Predicate {
-    virtual std::string ToString() const = 0;
-    virtual ~Predicate() = default;
+  virtual std::string ToString() const = 0;
+  virtual ~Predicate() = default;
 };
 
 struct PredicateFactory {
-    std::vector<std::unique_ptr<Predicate>> predicates;
+  std::vector<std::unique_ptr<Predicate>> predicates;
 
-    template<typename T, typename... Args>
-    T* Make(Args&&... args) {
-        std::unique_ptr<T> value =
-            absl::make_unique<T>(std::forward<Args>(args)...);
-        T* ptr = value.get();
-        predicates.push_back(std::move(value));
-        return ptr;
-    }
+  template <typename T, typename... Args> T *Make(Args &&...args) {
+    std::unique_ptr<T> value =
+        absl::make_unique<T>(std::forward<Args>(args)...);
+    T *ptr = value.get();
+    predicates.push_back(std::move(value));
+    return ptr;
+  }
 };
 
 struct PredicateAnd : public Predicate {
-    std::vector<Predicate*> children;
+  std::vector<Predicate *> children;
 
-    explicit PredicateAnd(
-        absl::Span<Predicate* const> children_)
-        : children(children_.begin(), children_.end()) {}
+  explicit PredicateAnd(absl::Span<Predicate *const> children_)
+      : children(children_.begin(), children_.end()) {}
 
-    std::string ToString() const override {
-        std::vector<std::string> child_strings;
-        for (Predicate* child : children) {
-            child_strings.push_back(child->ToString());
-        }
-        return absl::StrCat("(", absl::StrJoin(child_strings, " && "), ")");
+  std::string ToString() const override {
+    std::vector<std::string> child_strings;
+    for (Predicate *child : children) {
+      child_strings.push_back(child->ToString());
     }
+    return absl::StrCat("(", absl::StrJoin(child_strings, " && "), ")");
+  }
 };
 
 struct PredicateOr : public Predicate {
-    std::vector<Predicate*> children;
+  std::vector<Predicate *> children;
 
-    explicit PredicateOr(
-        absl::Span<Predicate* const> children_)
-        : children(children_.begin(), children_.end()) {}
+  explicit PredicateOr(absl::Span<Predicate *const> children_)
+      : children(children_.begin(), children_.end()) {}
 
-    std::string ToString() const override {
-        std::vector<std::string> child_strings;
-        for (Predicate* child : children) {
-            child_strings.push_back(child->ToString());
-        }
-        return absl::StrCat("(", absl::StrJoin(child_strings, " || "), ")");
+  std::string ToString() const override {
+    std::vector<std::string> child_strings;
+    for (Predicate *child : children) {
+      child_strings.push_back(child->ToString());
     }
+    return absl::StrCat("(", absl::StrJoin(child_strings, " || "), ")");
+  }
 };
 
 struct PredicateNot : public Predicate {
-    Predicate* pred;
+  Predicate *pred;
 
-    explicit PredicateNot(Predicate* pred_)
-        : pred(pred_) {}
+  explicit PredicateNot(Predicate *pred_) : pred(pred_) {}
 
-    std::string ToString() const override {
-        return absl::StrCat("!", pred->ToString());
-    }
+  std::string ToString() const override {
+    return absl::StrCat("!", pred->ToString());
+  }
 };
 
 struct PredicateLike : public Predicate {
-    Attr attr;
-    std::string string;
+  Attr attr;
+  std::string string;
 
-    PredicateLike(Attr attr_, const std::string& string_)
-        : attr(attr_), string(string_) {}
+  PredicateLike(Attr attr_, const std::string &string_)
+      : attr(attr_), string(string_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("(attr%d LIKE \"%s\")", attr, string);
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("(attr%d LIKE \"%s\")", attr, string);
+  }
 };
 
 struct PredicateLessThan : public Predicate {
-    Attr attr;
-    int32_t integer;
+  Attr attr;
+  int32_t integer;
 
-    PredicateLessThan(Attr attr_, int32_t integer_)
-        : attr(attr_), integer(integer_) {}
+  PredicateLessThan(Attr attr_, int32_t integer_)
+      : attr(attr_), integer(integer_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("(attr%d < %d)", attr, integer);
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("(attr%d < %d)", attr, integer);
+  }
 };
 
 struct PredicateEquals : public Predicate {
-    Attr attr;
-    int32_t integer;
+  Attr attr;
+  int32_t integer;
 
-    PredicateEquals(Attr attr_, int32_t integer_)
-        : attr(attr_), integer(integer_) {}
+  PredicateEquals(Attr attr_, int32_t integer_)
+      : attr(attr_), integer(integer_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("(attr%d ≡ %d)", attr, integer);
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("(attr%d ≡ %d)", attr, integer);
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Relation {
-    virtual std::string ToString() const = 0;
-    virtual int32_t Arity() const = 0;
-    virtual ~Relation() = default;
+  virtual std::string ToString() const = 0;
+  virtual int32_t Arity() const = 0;
+  virtual ~Relation() = default;
 };
 
 struct RelationFactory {
-    std::vector<std::unique_ptr<Relation>> relations;
+  std::vector<std::unique_ptr<Relation>> relations;
 
-    template<typename T, typename... Args>
-    T* Make(Args&&... args) {
-        std::unique_ptr<T> value =
-            absl::make_unique<T>(std::forward<Args>(args)...);
-        T* ptr = value.get();
-        relations.push_back(std::move(value));
-        return ptr;
-    }
+  template <typename T, typename... Args> T *Make(Args &&...args) {
+    std::unique_ptr<T> value =
+        absl::make_unique<T>(std::forward<Args>(args)...);
+    T *ptr = value.get();
+    relations.push_back(std::move(value));
+    return ptr;
+  }
 };
 
-template<typename S, typename T>
-absl::optional<T*> DynamicCast(S* pointer) {
-    T* casted = dynamic_cast<T*>(pointer);
-    if (casted == nullptr) { return absl::nullopt; }
-    return casted;
+template <typename S, typename T> absl::optional<T *> DynamicCast(S *pointer) {
+  T *casted = dynamic_cast<T *>(pointer);
+  if (casted == nullptr) {
+    return absl::nullopt;
+  }
+  return casted;
 }
 
 struct RelationReference : public Relation {
-    std::string name;
-    int32_t arity;
+  std::string name;
+  int32_t arity;
 
-    explicit RelationReference(absl::string_view name_, int32_t arity_)
-        : name(name_), arity(arity_) {}
+  explicit RelationReference(absl::string_view name_, int32_t arity_)
+      : name(name_), arity(arity_) {}
 
-    std::string ToString() const override {
-        return name;
-    }
+  std::string ToString() const override { return name; }
 
-    int32_t Arity() const override {
-        return arity;
-    }
+  int32_t Arity() const override { return arity; }
 };
 
 using JoinOn = absl::btree_set<std::pair<Attr, Attr>>;
 
 struct RelationJoin : public Relation {
-    Relation* lhs;
-    Relation* rhs;
-    JoinOn attributes;
+  Relation *lhs;
+  Relation *rhs;
+  JoinOn attributes;
 
-    RelationJoin(
-        Relation* lhs_,
-        Relation* rhs_,
-        const JoinOn& attributes_)
-        : lhs(lhs_), rhs(rhs_), attributes(attributes_) {}
+  RelationJoin(Relation *lhs_, Relation *rhs_, const JoinOn &attributes_)
+      : lhs(lhs_), rhs(rhs_), attributes(attributes_) {}
 
-    std::string ToString() const override {
-        std::vector<std::string> attribute_strings;
-        for (const auto& [x, y] : this->attributes) {
-            attribute_strings.push_back(absl::StrFormat("(%d, %d)", x, y));
-        }
-        return absl::StrFormat("Join([%s], %s, %s)",
-                               absl::StrJoin(attribute_strings, ", "),
-                               lhs->ToString(),
-                               rhs->ToString());
+  std::string ToString() const override {
+    std::vector<std::string> attribute_strings;
+    for (const auto &[x, y] : this->attributes) {
+      attribute_strings.push_back(absl::StrFormat("(%d, %d)", x, y));
     }
+    return absl::StrFormat("Join([%s], %s, %s)",
+                           absl::StrJoin(attribute_strings, ", "),
+                           lhs->ToString(), rhs->ToString());
+  }
 
-    int32_t Arity() const override {
-        int32_t lhs_arity = lhs->Arity();
-        int32_t rhs_arity = rhs->Arity();
-        int32_t result_arity = lhs_arity + rhs_arity - attributes.size();
-        RDSS_CHECK_GE(result_arity, 0) << "type error got past the typechecker";
-        return result_arity;
-    }
+  int32_t Arity() const override {
+    int32_t lhs_arity = lhs->Arity();
+    int32_t rhs_arity = rhs->Arity();
+    int32_t result_arity = lhs_arity + rhs_arity - attributes.size();
+    RDSS_CHECK_GE(result_arity, 0) << "type error got past the typechecker";
+    return result_arity;
+  }
 };
 
 struct RelationSemijoin : public Relation {
-    Relation* lhs;
-    Relation* rhs;
-    JoinOn attributes;
+  Relation *lhs;
+  Relation *rhs;
+  JoinOn attributes;
 
-    RelationSemijoin(
-        Relation* lhs_,
-        Relation* rhs_,
-        const JoinOn& attributes_)
-        : lhs(lhs_), rhs(rhs_), attributes(attributes_) {}
+  RelationSemijoin(Relation *lhs_, Relation *rhs_, const JoinOn &attributes_)
+      : lhs(lhs_), rhs(rhs_), attributes(attributes_) {}
 
-    std::string ToString() const override {
-        std::vector<std::string> attribute_strings;
-        for (const auto& [x, y] : this->attributes) {
-            attribute_strings.push_back(absl::StrFormat("(%d, %d)", x, y));
-        }
-        return absl::StrFormat("Semijoin([%s], %s, %s)",
-                               absl::StrJoin(attribute_strings, ", "),
-                               lhs->ToString(),
-                               rhs->ToString());
+  std::string ToString() const override {
+    std::vector<std::string> attribute_strings;
+    for (const auto &[x, y] : this->attributes) {
+      attribute_strings.push_back(absl::StrFormat("(%d, %d)", x, y));
     }
+    return absl::StrFormat("Semijoin([%s], %s, %s)",
+                           absl::StrJoin(attribute_strings, ", "),
+                           lhs->ToString(), rhs->ToString());
+  }
 
-    int32_t Arity() const override {
-        return lhs->Arity();
-    }
+  int32_t Arity() const override { return lhs->Arity(); }
 };
 
 struct RelationUnion : public Relation {
-    Relation* lhs;
-    Relation* rhs;
+  Relation *lhs;
+  Relation *rhs;
 
-    RelationUnion(Relation* lhs_,
-                  Relation* rhs_)
-        : lhs(lhs_), rhs(rhs_) {}
+  RelationUnion(Relation *lhs_, Relation *rhs_) : lhs(lhs_), rhs(rhs_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("Union(%s, %s)",
-                               lhs->ToString(),
-                               rhs->ToString());
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("Union(%s, %s)", lhs->ToString(), rhs->ToString());
+  }
 
-    int32_t Arity() const override {
-        int32_t lhs_arity = lhs->Arity();
-        int32_t rhs_arity = rhs->Arity();
-        RDSS_CHECK_EQ(lhs_arity, rhs_arity)
-            << "type error got past the typechecker";
-        return lhs_arity;
-    }
+  int32_t Arity() const override {
+    int32_t lhs_arity = lhs->Arity();
+    int32_t rhs_arity = rhs->Arity();
+    RDSS_CHECK_EQ(lhs_arity, rhs_arity)
+        << "type error got past the typechecker";
+    return lhs_arity;
+  }
 };
 
 struct RelationDifference : public Relation {
-    Relation* lhs;
-    Relation* rhs;
+  Relation *lhs;
+  Relation *rhs;
 
-    RelationDifference(Relation* lhs_,
-                       Relation* rhs_)
-        : lhs(lhs_), rhs(rhs_) {}
+  RelationDifference(Relation *lhs_, Relation *rhs_) : lhs(lhs_), rhs(rhs_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("Difference(%s, %s)",
-                               lhs->ToString(),
-                               rhs->ToString());
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("Difference(%s, %s)", lhs->ToString(),
+                           rhs->ToString());
+  }
 
-    int32_t Arity() const override {
-        int32_t lhs_arity = lhs->Arity();
-        int32_t rhs_arity = rhs->Arity();
-        RDSS_CHECK_EQ(lhs_arity, rhs_arity)
-            << "type error got past the typechecker";
-        return lhs_arity;
-    }
+  int32_t Arity() const override {
+    int32_t lhs_arity = lhs->Arity();
+    int32_t rhs_arity = rhs->Arity();
+    RDSS_CHECK_EQ(lhs_arity, rhs_arity)
+        << "type error got past the typechecker";
+    return lhs_arity;
+  }
 };
 
 struct RelationSelect : public Relation {
-    Predicate* predicate;
-    Relation* rel;
+  Predicate *predicate;
+  Relation *rel;
 
-    RelationSelect(Predicate* predicate_,
-                   Relation* rel_)
-        : predicate(predicate_), rel(rel_) {}
+  RelationSelect(Predicate *predicate_, Relation *rel_)
+      : predicate(predicate_), rel(rel_) {}
 
-    std::string ToString() const override {
-        // FIXME: add pretty-printing for predicates
-        return absl::StrFormat("Select(<predicate>, %s)",
-                               rel->ToString());
-    }
+  std::string ToString() const override {
+    // FIXME: add pretty-printing for predicates
+    return absl::StrFormat("Select(<predicate>, %s)", rel->ToString());
+  }
 
-    int32_t Arity() const override {
-        return rel->Arity();
-    }
+  int32_t Arity() const override { return rel->Arity(); }
 };
 
 struct RelationMap : public Relation {
-    Function function;
-    Relation* rel;
+  Function function;
+  Relation *rel;
 
-    RelationMap(const Function& function_,
-                Relation* rel_)
-        : function(function_), rel(rel_) {}
+  RelationMap(const Function &function_, Relation *rel_)
+      : function(function_), rel(rel_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("Map(%s, %s)",
-                               function.name,
-                               rel->ToString());
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("Map(%s, %s)", function.name, rel->ToString());
+  }
 
-    int32_t Arity() const override {
-        RDSS_CHECK_EQ(function.arguments, rel->Arity())
-            << "type error got past the typechecker";
-        return function.results;
-    }
+  int32_t Arity() const override {
+    RDSS_CHECK_EQ(function.arguments, rel->Arity())
+        << "type error got past the typechecker";
+    return function.results;
+  }
 };
 
 struct RelationView : public Relation {
-    Viewed<Relation*> rel;
+  Viewed<Relation *> rel;
 
-    RelationView(const Viewed<Relation*>& rel_) : rel(rel_) {}
+  RelationView(const Viewed<Relation *> &rel_) : rel(rel_) {}
 
-    std::string ToString() const override {
-        return absl::StrFormat("View(%s)",
-                               rel.ToString());
-    }
+  std::string ToString() const override {
+    return absl::StrFormat("View(%s)", rel.ToString());
+  }
 
-    int32_t Arity() const override {
-        return rel.Arity();
-    }
+  int32_t Arity() const override { return rel.Arity(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TypeParameter {
-    std::string name;
+  std::string name;
 
-    TypeParameter(absl::string_view name_) : name(name_) {}
+  TypeParameter(absl::string_view name_) : name(name_) {}
 
-    std::string ToCpp() const { return this->name; }
+  std::string ToCpp() const { return this->name; }
 };
 
 struct VarName {
-    std::string name;
+  std::string name;
 
-    VarName(absl::string_view name_) : name(name_) {}
+  VarName(absl::string_view name_) : name(name_) {}
 
-    std::string ToCpp() const { return this->name; }
+  std::string ToCpp() const { return this->name; }
 };
 
 struct TypeName {
-    std::string name;
+  std::string name;
 
-    TypeName(absl::string_view name_) : name(name_) {}
+  TypeName(absl::string_view name_) : name(name_) {}
 
-    std::string ToCpp() const { return this->name; }
+  std::string ToCpp() const { return this->name; }
 };
 
 struct FreshVariableSource {
-    FreshVariableSource() : number(0) {}
+  FreshVariableSource() : number(0) {}
 
-    VarName Fresh() {
-        std::string result = absl::StrFormat("fresh%d", number);
-        number++;
-        return VarName(result);
-    }
+  VarName Fresh() {
+    std::string result = absl::StrFormat("fresh%d", number);
+    number++;
+    return VarName(result);
+  }
 
 private:
-    int32_t number;
+  int32_t number;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Type {
-    virtual std::string ToCpp() const = 0;
-    virtual ~Type() = default;
+  virtual std::string ToCpp() const = 0;
+  virtual ~Type() = default;
 };
 
 struct TypeInt : public Type {
-    TypeInt() {}
+  TypeInt() {}
 
-    std::string ToCpp() const override {
-        return "int32_t";
-    }
+  std::string ToCpp() const override { return "int32_t"; }
 };
 
 struct TypeBasic : public Type {
-    TypeName name;
+  TypeName name;
 
-    TypeBasic(TypeName name_) : name(name_) {}
+  TypeBasic(TypeName name_) : name(name_) {}
 
-    std::string ToCpp() const override {
-        return this->name.ToCpp();
-    }
+  std::string ToCpp() const override { return this->name.ToCpp(); }
 };
 
 struct TypeRow : public Type {
-    std::vector<Type*> elements;
+  std::vector<Type *> elements;
 
-    TypeRow(absl::Span<Type* const> elements_)
-        : elements(elements_.begin(), elements_.end()) {}
+  TypeRow(absl::Span<Type *const> elements_)
+      : elements(elements_.begin(), elements_.end()) {}
 
-    std::string ToCpp() const override {
-        std::stringstream ss;
-        ss << "std::tuple<";
-        std::vector<std::string> types;
-        for (const auto& type : this->elements) {
-            types.push_back(type->ToCpp());
-        }
-        ss << absl::StrJoin(types, ", ") << ">";
-        return ss.str();
+  std::string ToCpp() const override {
+    std::stringstream ss;
+    ss << "std::tuple<";
+    std::vector<std::string> types;
+    for (const auto &type : this->elements) {
+      types.push_back(type->ToCpp());
     }
+    ss << absl::StrJoin(types, ", ") << ">";
+    return ss.str();
+  }
 };
 
 struct TypeHashSet : public Type {
-    Type* element;
+  Type *element;
 
-    TypeHashSet(Type* element_) : element(element_) {}
+  TypeHashSet(Type *element_) : element(element_) {}
 
-    std::string ToCpp() const override {
-        return absl::StrCat("absl::flat_hash_set<",
-                            this->element->ToCpp(), ">");
-    }
+  std::string ToCpp() const override {
+    return absl::StrCat("absl::flat_hash_set<", this->element->ToCpp(), ">");
+  }
 };
 
 struct TypeBag : public Type {
-    Type* element;
+  Type *element;
 
-    TypeBag(Type* element_) : element(element_) {}
+  TypeBag(Type *element_) : element(element_) {}
 
-    std::string ToCpp() const override {
-        return absl::StrCat("absl::flat_hash_map<",
-                            this->element->ToCpp(), ", int32_t>");
-    }
+  std::string ToCpp() const override {
+    return absl::StrCat("absl::flat_hash_map<", this->element->ToCpp(),
+                        ", int32_t>");
+  }
 };
 
 struct TypeHashMap : public Type {
-    Type* key;
-    Type* value;
+  Type *key;
+  Type *value;
 
-    TypeHashMap(Type* key_, Type* value_) : key(key_), value(value_) {}
+  TypeHashMap(Type *key_, Type *value_) : key(key_), value(value_) {}
 
-    std::string ToCpp() const override {
-        return absl::StrCat("absl::flat_hash_map<",
-                            this->key->ToCpp(), ", ",
-                            this->value->ToCpp(), ">");
-    }
+  std::string ToCpp() const override {
+    return absl::StrCat("absl::flat_hash_map<", this->key->ToCpp(), ", ",
+                        this->value->ToCpp(), ">");
+  }
 };
 
 struct TypeTrie : public Type {
-    Type* key;
-    Type* value;
+  Type *key;
+  Type *value;
 
-    TypeTrie(Type* key_, Type* value_) : key(key_), value(value_) {}
+  TypeTrie(Type *key_, Type *value_) : key(key_), value(value_) {}
 
-    std::string ToCpp() const override {
-        return absl::StrCat("trie<",
-                            this->key->ToCpp(), ", ",
-                            this->value->ToCpp(), ">");
-    }
+  std::string ToCpp() const override {
+    return absl::StrCat("trie<", this->key->ToCpp(), ", ", this->value->ToCpp(),
+                        ">");
+  }
 };
 
 struct TypeVector : public Type {
-    Type* element;
+  Type *element;
 
-    TypeVector(Type* element_) : element(element_) {}
+  TypeVector(Type *element_) : element(element_) {}
 
-    std::string ToCpp() const override {
-        return absl::StrCat("std::vector<", this->element->ToCpp(), ">");
-    }
+  std::string ToCpp() const override {
+    return absl::StrCat("std::vector<", this->element->ToCpp(), ">");
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 inline std::string Indent(absl::string_view str, int32_t n) {
-    std::vector<absl::string_view> lines = absl::StrSplit(str, '\n');
-    std::string indent;
-    indent.resize(4 * n, ' ');
-    std::stringstream ss;
-    for (auto line : lines) {
-        if (!line.empty()) {
-            ss << indent << line << "\n";
-        }
+  std::vector<absl::string_view> lines = absl::StrSplit(str, '\n');
+  std::string indent;
+  indent.resize(4 * n, ' ');
+  std::stringstream ss;
+  for (auto line : lines) {
+    if (!line.empty()) {
+      ss << indent << line << "\n";
     }
-    return ss.str();
+  }
+  return ss.str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -554,458 +511,414 @@ inline std::string Indent(absl::string_view str, int32_t n) {
 // TODO: created Typed<T> to streamline access to type information
 
 struct Action {
-    virtual std::string ToCpp(FreshVariableSource* source) const = 0;
+  virtual std::string ToCpp(FreshVariableSource *source) const = 0;
 };
 
 struct ActionGetMember : public Action {
-    VarName variable;
-    VarName pointer;
-    VarName struct_field;
+  VarName variable;
+  VarName pointer;
+  VarName struct_field;
 
-    ActionGetMember(VarName variable_, VarName pointer_, VarName struct_field_)
-        : variable(variable_), pointer(pointer_), struct_field(struct_field_)
-        {}
+  ActionGetMember(VarName variable_, VarName pointer_, VarName struct_field_)
+      : variable(variable_), pointer(pointer_), struct_field(struct_field_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s = %s.%s;",
-                               variable.ToCpp(),
-                               pointer.ToCpp(),
-                               struct_field.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s = %s.%s;", variable.ToCpp(), pointer.ToCpp(),
+                           struct_field.ToCpp());
+  }
 };
 
 struct ActionIfEquals : public Action {
-    std::vector<std::pair<VarName, VarName>> equalities;
-    std::vector<Action*> body;
+  std::vector<std::pair<VarName, VarName>> equalities;
+  std::vector<Action *> body;
 
-    ActionIfEquals(absl::Span<std::pair<VarName, VarName> const> equalities_,
-                   absl::Span<Action* const> body_)
-        : equalities(equalities_.begin(), equalities_.end())
-        , body(body_.begin(), body_.end()) {}
+  ActionIfEquals(absl::Span<std::pair<VarName, VarName> const> equalities_,
+                 absl::Span<Action *const> body_)
+      : equalities(equalities_.begin(), equalities_.end()),
+        body(body_.begin(), body_.end()) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        std::vector<std::string> equality_strings;
-        for (const auto& [x, y] : this->equalities) {
-            equality_strings.push_back(absl::StrFormat("(%s == %s)",
-                                                       x.ToCpp(),
-                                                       y.ToCpp()));
-        }
-        std::string body_string;
-        for (const auto& action : this->body) {
-            absl::StrAppend(
-                &body_string, Indent(action->ToCpp(source), 1), "\n");
-        }
-        return absl::StrFormat("if (%s) {\n%s}",
-                               absl::StrJoin(equality_strings, " || "),
-                               body_string);
+  std::string ToCpp(FreshVariableSource *source) const override {
+    std::vector<std::string> equality_strings;
+    for (const auto &[x, y] : this->equalities) {
+      equality_strings.push_back(
+          absl::StrFormat("(%s == %s)", x.ToCpp(), y.ToCpp()));
     }
+    std::string body_string;
+    for (const auto &action : this->body) {
+      absl::StrAppend(&body_string, Indent(action->ToCpp(source), 1), "\n");
+    }
+    return absl::StrFormat(
+        "if (%s) {\n%s}", absl::StrJoin(equality_strings, " || "), body_string);
+  }
 };
 
 struct ActionAssignConstant : public Action {
-    VarName variable;
-    std::string constant;
+  VarName variable;
+  std::string constant;
 
-    ActionAssignConstant(VarName variable_, absl::string_view constant_)
-        : variable(variable_), constant(constant_) {}
+  ActionAssignConstant(VarName variable_, absl::string_view constant_)
+      : variable(variable_), constant(constant_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("auto %s = %s;", variable.ToCpp(), constant);
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("auto %s = %s;", variable.ToCpp(), constant);
+  }
 };
 
 struct ActionCreateRow : public Action {
-    VarName variable;
-    std::vector<std::pair<VarName, Type*>> elements;
+  VarName variable;
+  std::vector<std::pair<VarName, Type *>> elements;
 
-    explicit ActionCreateRow(VarName variable_)
-        : variable(variable_), elements() {}
+  explicit ActionCreateRow(VarName variable_)
+      : variable(variable_), elements() {}
 
-    ActionCreateRow(VarName variable_,
-                    absl::Span<const std::pair<VarName, Type*>> elements_)
-        : variable(variable_), elements(elements_.begin(), elements_.end()) {}
+  ActionCreateRow(VarName variable_,
+                  absl::Span<const std::pair<VarName, Type *>> elements_)
+      : variable(variable_), elements(elements_.begin(), elements_.end()) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        std::vector<std::string> element_strings;
-        std::vector<std::string> type_strings;
-        for (const auto& [element, type] : elements) {
-            element_strings.push_back(element.ToCpp());
-            type_strings.push_back(type->ToCpp());
-        }
-        return absl::StrFormat("std::tuple<%s> %s { %s };",
-                               absl::StrJoin(type_strings, ", "),
-                               variable.ToCpp(),
-                               absl::StrJoin(element_strings, ", "));
+  std::string ToCpp(FreshVariableSource *source) const override {
+    std::vector<std::string> element_strings;
+    std::vector<std::string> type_strings;
+    for (const auto &[element, type] : elements) {
+      element_strings.push_back(element.ToCpp());
+      type_strings.push_back(type->ToCpp());
     }
+    return absl::StrFormat("std::tuple<%s> %s { %s };",
+                           absl::StrJoin(type_strings, ", "), variable.ToCpp(),
+                           absl::StrJoin(element_strings, ", "));
+  }
 };
 
 struct ActionIndexRow : public Action {
-    VarName variable;
-    VarName row_to_index;
-    uint32_t index;
+  VarName variable;
+  VarName row_to_index;
+  uint32_t index;
 
-    ActionIndexRow(VarName variable_, VarName row_to_index_, uint32_t index_)
-        : variable(variable_), row_to_index(row_to_index_), index(index_) {}
+  ActionIndexRow(VarName variable_, VarName row_to_index_, uint32_t index_)
+      : variable(variable_), row_to_index(row_to_index_), index(index_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("auto %s = std::get<%d>(%s);",
-                               variable.ToCpp(),
-                               index,
-                               row_to_index.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("auto %s = std::get<%d>(%s);", variable.ToCpp(),
+                           index, row_to_index.ToCpp());
+  }
 };
 
 struct ActionInvoke : public Action {
-    VarName method;
-    std::vector<VarName> arguments;
+  VarName method;
+  std::vector<VarName> arguments;
 
-    ActionInvoke(VarName method_, absl::Span<const VarName> arguments_)
-        : method(method_), arguments(arguments_.begin(), arguments_.end()) {}
+  ActionInvoke(VarName method_, absl::Span<const VarName> arguments_)
+      : method(method_), arguments(arguments_.begin(), arguments_.end()) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        std::vector<std::string> argument_strings;
-        for (const VarName& argument : arguments) {
-            argument_strings.push_back(argument.ToCpp());
-        }
-        return absl::StrFormat("%s(%s);",
-                               method.ToCpp(),
-                               absl::StrJoin(argument_strings, ", "));
+  std::string ToCpp(FreshVariableSource *source) const override {
+    std::vector<std::string> argument_strings;
+    for (const VarName &argument : arguments) {
+      argument_strings.push_back(argument.ToCpp());
     }
+    return absl::StrFormat("%s(%s);", method.ToCpp(),
+                           absl::StrJoin(argument_strings, ", "));
+  }
 };
 
 struct ActionCreateHashSet : public Action {
-    VarName variable;
-    Type* type;
+  VarName variable;
+  Type *type;
 
-    ActionCreateHashSet(VarName variable_, Type* type_)
-        : variable(variable_), type(type_) {}
+  ActionCreateHashSet(VarName variable_, Type *type_)
+      : variable(variable_), type(type_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("absl::flat_hash_set<%s> %s;",
-                               type->ToCpp(),
-                               variable.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("absl::flat_hash_set<%s> %s;", type->ToCpp(),
+                           variable.ToCpp());
+  }
 };
 
 struct ActionInsertHashSet : public Action {
-    VarName hash_set;
-    VarName value_to_insert;
+  VarName hash_set;
+  VarName value_to_insert;
 
-    ActionInsertHashSet(VarName hash_set_, VarName value_to_insert_)
-        : hash_set(hash_set_), value_to_insert(value_to_insert_) {}
+  ActionInsertHashSet(VarName hash_set_, VarName value_to_insert_)
+      : hash_set(hash_set_), value_to_insert(value_to_insert_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.insert(%s);",
-                               hash_set.ToCpp(),
-                               value_to_insert.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.insert(%s);", hash_set.ToCpp(),
+                           value_to_insert.ToCpp());
+  }
 };
 
 struct ActionDeleteHashSet : public Action {
-    VarName hash_set;
-    VarName value_to_delete;
+  VarName hash_set;
+  VarName value_to_delete;
 
-    ActionDeleteHashSet(VarName hash_set_, VarName value_to_delete_)
-        : hash_set(hash_set_), value_to_delete(value_to_delete_) {}
+  ActionDeleteHashSet(VarName hash_set_, VarName value_to_delete_)
+      : hash_set(hash_set_), value_to_delete(value_to_delete_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.erase(%s);",
-                               hash_set.ToCpp(),
-                               value_to_delete.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.erase(%s);", hash_set.ToCpp(),
+                           value_to_delete.ToCpp());
+  }
 };
 
 struct ActionIterateOverHashSet : public Action {
-    VarName hash_set;
-    std::function<std::vector<Action*>(VarName)> body;
+  VarName hash_set;
+  std::function<std::vector<Action *>(VarName)> body;
 
-    ActionIterateOverHashSet(VarName hash_set_,
-                             std::function<std::vector<Action*>(VarName)> body_)
-        : hash_set(hash_set_), body(body_) {}
+  ActionIterateOverHashSet(VarName hash_set_,
+                           std::function<std::vector<Action *>(VarName)> body_)
+      : hash_set(hash_set_), body(body_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        auto value = source->Fresh();
-        std::string body_string;
-        for (const auto& action : this->body(value)) {
-            absl::StrAppend(
-                &body_string, Indent(action->ToCpp(source), 1), "\n");
-        }
-        return absl::StrFormat("for (const auto& %s : %s) {\n%s}",
-                               value.ToCpp(),
-                               hash_set.ToCpp(),
-                               body_string);
+  std::string ToCpp(FreshVariableSource *source) const override {
+    auto value = source->Fresh();
+    std::string body_string;
+    for (const auto &action : this->body(value)) {
+      absl::StrAppend(&body_string, Indent(action->ToCpp(source), 1), "\n");
     }
+    return absl::StrFormat("for (const auto& %s : %s) {\n%s}", value.ToCpp(),
+                           hash_set.ToCpp(), body_string);
+  }
 };
 
 struct ActionContainsHashSet : public Action {
-    VarName variable;
-    VarName hash_set;
-    VarName value;
+  VarName variable;
+  VarName hash_set;
+  VarName value;
 
-    ActionContainsHashSet(VarName variable_, VarName hash_set_, VarName value_)
-        : variable(variable_), hash_set(hash_set_), value(value_) {}
+  ActionContainsHashSet(VarName variable_, VarName hash_set_, VarName value_)
+      : variable(variable_), hash_set(hash_set_), value(value_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("bool %s = %s.contains(%s);",
-                               variable.ToCpp(),
-                               hash_set.ToCpp(),
-                               value.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("bool %s = %s.contains(%s);", variable.ToCpp(),
+                           hash_set.ToCpp(), value.ToCpp());
+  }
 };
 
 struct ActionCreateHashMap : public Action {
-    VarName variable;
-    Type* key_type;
-    Type* value_type;
+  VarName variable;
+  Type *key_type;
+  Type *value_type;
 
-    ActionCreateHashMap(VarName variable_, Type* key_type_, Type* value_type_)
-        : variable(variable_), key_type(key_type_), value_type(value_type_) {}
+  ActionCreateHashMap(VarName variable_, Type *key_type_, Type *value_type_)
+      : variable(variable_), key_type(key_type_), value_type(value_type_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("absl::flat_hash_map<%s, %s> %s;",
-                               key_type->ToCpp(),
-                               value_type->ToCpp(),
-                               variable.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("absl::flat_hash_map<%s, %s> %s;", key_type->ToCpp(),
+                           value_type->ToCpp(), variable.ToCpp());
+  }
 };
 
 struct ActionInsertHashMap : public Action {
-    VarName hash_map;
-    VarName key_to_insert;
-    VarName value_to_insert;
+  VarName hash_map;
+  VarName key_to_insert;
+  VarName value_to_insert;
 
-    ActionInsertHashMap(VarName hash_map_,
-                        VarName key_to_insert_,
-                        VarName value_to_insert_)
-        : hash_map(hash_map_)
-        , key_to_insert(key_to_insert_)
-        , value_to_insert(value_to_insert_) {}
+  ActionInsertHashMap(VarName hash_map_, VarName key_to_insert_,
+                      VarName value_to_insert_)
+      : hash_map(hash_map_), key_to_insert(key_to_insert_),
+        value_to_insert(value_to_insert_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.insert_or_assign(%s, %s);",
-                               hash_map.ToCpp(),
-                               key_to_insert.ToCpp(),
-                               value_to_insert.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.insert_or_assign(%s, %s);", hash_map.ToCpp(),
+                           key_to_insert.ToCpp(), value_to_insert.ToCpp());
+  }
 };
 
 struct ActionDeleteHashMap : public Action {
-    VarName hash_map;
-    VarName key_to_delete;
+  VarName hash_map;
+  VarName key_to_delete;
 
-    ActionDeleteHashMap(VarName hash_map_,
-                        VarName key_to_delete_)
-        : hash_map(hash_map_), key_to_delete(key_to_delete_) {}
+  ActionDeleteHashMap(VarName hash_map_, VarName key_to_delete_)
+      : hash_map(hash_map_), key_to_delete(key_to_delete_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.erase(%s);",
-                               hash_map.ToCpp(),
-                               key_to_delete.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.erase(%s);", hash_map.ToCpp(),
+                           key_to_delete.ToCpp());
+  }
 };
 
 struct ActionIterateOverHashMap : public Action {
-    VarName hash_map;
-    std::function<std::vector<Action*>(VarName, VarName)> body;
+  VarName hash_map;
+  std::function<std::vector<Action *>(VarName, VarName)> body;
 
-    ActionIterateOverHashMap(
-        VarName hash_map_,
-        std::function<std::vector<Action*>(VarName, VarName)> body_)
-        : hash_map(hash_map_), body(body_) {}
+  ActionIterateOverHashMap(
+      VarName hash_map_,
+      std::function<std::vector<Action *>(VarName, VarName)> body_)
+      : hash_map(hash_map_), body(body_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        auto key = source->Fresh();
-        auto value = source->Fresh();
-        std::string body_string;
-        for (const auto& action : this->body(key, value)) {
-            absl::StrAppend(&body_string, action->ToCpp(source), "\n");
-        }
-        return absl::StrFormat("for (const auto& [%s, %s] : %s) {\n%s}",
-                               key.ToCpp(),
-                               value.ToCpp(),
-                               hash_map.ToCpp(),
-                               body_string);
+  std::string ToCpp(FreshVariableSource *source) const override {
+    auto key = source->Fresh();
+    auto value = source->Fresh();
+    std::string body_string;
+    for (const auto &action : this->body(key, value)) {
+      absl::StrAppend(&body_string, action->ToCpp(source), "\n");
     }
+    return absl::StrFormat("for (const auto& [%s, %s] : %s) {\n%s}",
+                           key.ToCpp(), value.ToCpp(), hash_map.ToCpp(),
+                           body_string);
+  }
 };
 
 struct ActionCreateTrie : public Action {
-    VarName variable;
-    Type* key_type;
-    Type* value_type;
+  VarName variable;
+  Type *key_type;
+  Type *value_type;
 
-    ActionCreateTrie(VarName variable_, Type* key_type_, Type* value_type_)
-        : variable(variable_), key_type(key_type_), value_type(value_type_) {}
+  ActionCreateTrie(VarName variable_, Type *key_type_, Type *value_type_)
+      : variable(variable_), key_type(key_type_), value_type(value_type_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("Trie<%s, %s> %s;",
-                               key_type->ToCpp(),
-                               value_type->ToCpp(),
-                               variable.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("Trie<%s, %s> %s;", key_type->ToCpp(),
+                           value_type->ToCpp(), variable.ToCpp());
+  }
 };
 
 struct ActionInsertTrie : public Action {
-    VarName trie;
-    VarName key_to_insert;
-    VarName value_to_insert;
+  VarName trie;
+  VarName key_to_insert;
+  VarName value_to_insert;
 
-    ActionInsertTrie(VarName trie_,
-                     VarName key_to_insert_,
-                     VarName value_to_insert_)
-        : trie(trie_)
-        , key_to_insert(key_to_insert_)
-        , value_to_insert(value_to_insert_) {}
+  ActionInsertTrie(VarName trie_, VarName key_to_insert_,
+                   VarName value_to_insert_)
+      : trie(trie_), key_to_insert(key_to_insert_),
+        value_to_insert(value_to_insert_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.Insert(%s, %s);",
-                               this->trie.ToCpp(),
-                               this->key_to_insert.ToCpp(),
-                               this->value_to_insert.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.Insert(%s, %s);", this->trie.ToCpp(),
+                           this->key_to_insert.ToCpp(),
+                           this->value_to_insert.ToCpp());
+  }
 };
 
 struct ActionDeleteTrie : public Action {
-    VarName trie;
-    VarName key_to_delete;
+  VarName trie;
+  VarName key_to_delete;
 
-    ActionDeleteTrie(VarName trie_,
-                     VarName key_to_delete_)
-        : trie(trie_), key_to_delete(key_to_delete_) {}
+  ActionDeleteTrie(VarName trie_, VarName key_to_delete_)
+      : trie(trie_), key_to_delete(key_to_delete_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("%s.Delete(%s)",
-                               this->trie.ToCpp(),
-                               this->key_to_delete.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("%s.Delete(%s)", this->trie.ToCpp(),
+                           this->key_to_delete.ToCpp());
+  }
 };
 
 struct ActionCreateBag : public Action {
-    VarName variable;
-    Type* value_type;
+  VarName variable;
+  Type *value_type;
 
-    ActionCreateBag(VarName variable_, Type* value_type_)
-        : variable(variable_), value_type(value_type_) {}
+  ActionCreateBag(VarName variable_, Type *value_type_)
+      : variable(variable_), value_type(value_type_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("absl::flat_hash_map<%s, int32_t> %s;",
-                               value_type->ToCpp(),
-                               variable.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("absl::flat_hash_map<%s, int32_t> %s;",
+                           value_type->ToCpp(), variable.ToCpp());
+  }
 };
 
 struct ActionIncrementBag : public Action {
-    VarName bag;
-    VarName value_to_insert;
+  VarName bag;
+  VarName value_to_insert;
 
-    ActionIncrementBag(VarName bag_, VarName value_to_insert_)
-        : bag(bag_)
-        , value_to_insert(value_to_insert_) {}
+  ActionIncrementBag(VarName bag_, VarName value_to_insert_)
+      : bag(bag_), value_to_insert(value_to_insert_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        auto bag_cpp = this->bag.ToCpp();
-        auto value_cpp = this->value_to_insert.ToCpp();
-        return absl::StrFormat(
-            "if (%s.contains(%s)) { %s[%s]++; } else { %s[%s] = 1; }",
-            bag_cpp, value_cpp, bag_cpp, value_cpp, bag_cpp, value_cpp);
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    auto bag_cpp = this->bag.ToCpp();
+    auto value_cpp = this->value_to_insert.ToCpp();
+    return absl::StrFormat(
+        "if (%s.contains(%s)) { %s[%s]++; } else { %s[%s] = 1; }", bag_cpp,
+        value_cpp, bag_cpp, value_cpp, bag_cpp, value_cpp);
+  }
 };
 
 struct ActionDecrementBag : public Action {
-    VarName bag;
-    VarName value_to_delete;
+  VarName bag;
+  VarName value_to_delete;
 
-    ActionDecrementBag(VarName bag_, VarName value_to_delete_)
-        : bag(bag_), value_to_delete(value_to_delete_) {}
+  ActionDecrementBag(VarName bag_, VarName value_to_delete_)
+      : bag(bag_), value_to_delete(value_to_delete_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        auto bag_cpp = this->bag.ToCpp();
-        auto value_cpp = this->value_to_delete.ToCpp();
+  std::string ToCpp(FreshVariableSource *source) const override {
+    auto bag_cpp = this->bag.ToCpp();
+    auto value_cpp = this->value_to_delete.ToCpp();
 
-        return absl::StrFormat(
-            "if (%s.contains(%s)) { %s[%s]--; if (%s[%s] < 0) %s.erase(%s); }",
-            bag_cpp, value_cpp,
-            bag_cpp, value_cpp,
-            bag_cpp, value_cpp,
-            bag_cpp, value_cpp);
-    }
+    return absl::StrFormat(
+        "if (%s.contains(%s)) { %s[%s]--; if (%s[%s] < 0) %s.erase(%s); }",
+        bag_cpp, value_cpp, bag_cpp, value_cpp, bag_cpp, value_cpp, bag_cpp,
+        value_cpp);
+  }
 };
 
 struct ActionIterateOverBag : public Action {
-    VarName bag;
-    std::function<std::vector<Action*>(VarName)> body;
+  VarName bag;
+  std::function<std::vector<Action *>(VarName)> body;
 
-    ActionIterateOverBag(VarName bag_,
-                         std::function<std::vector<Action*>(VarName)> body_)
-        : bag(bag_), body(body_) {}
+  ActionIterateOverBag(VarName bag_,
+                       std::function<std::vector<Action *>(VarName)> body_)
+      : bag(bag_), body(body_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        auto value = source->Fresh();
-        std::string body_string;
-        for (const auto& action : this->body(value)) {
-            absl::StrAppend(
-                &body_string, Indent(action->ToCpp(source), 1), "\n");
-        }
-        return absl::StrFormat("for (const auto& [%s, %s] : %s) {\n%s}",
-                               value.ToCpp(),
-                               // multiplicities should be invisible
-                               source->Fresh().name,
-                               bag.ToCpp(),
-                               body_string);
+  std::string ToCpp(FreshVariableSource *source) const override {
+    auto value = source->Fresh();
+    std::string body_string;
+    for (const auto &action : this->body(value)) {
+      absl::StrAppend(&body_string, Indent(action->ToCpp(source), 1), "\n");
     }
+    return absl::StrFormat("for (const auto& [%s, %s] : %s) {\n%s}",
+                           value.ToCpp(),
+                           // multiplicities should be invisible
+                           source->Fresh().name, bag.ToCpp(), body_string);
+  }
 };
 
 struct ActionContainsBag : public Action {
-    VarName variable;
-    VarName bag;
-    VarName value;
+  VarName variable;
+  VarName bag;
+  VarName value;
 
-    ActionContainsBag(VarName variable_, VarName bag_, VarName value_)
-        : variable(variable_), bag(bag_), value(value_) {}
+  ActionContainsBag(VarName variable_, VarName bag_, VarName value_)
+      : variable(variable_), bag(bag_), value(value_) {}
 
-    std::string ToCpp(FreshVariableSource* source) const override {
-        return absl::StrFormat("bool %s = %s.contains(%s);",
-                               variable.ToCpp(),
-                               bag.ToCpp(),
-                               value.ToCpp());
-    }
+  std::string ToCpp(FreshVariableSource *source) const override {
+    return absl::StrFormat("bool %s = %s.contains(%s);", variable.ToCpp(),
+                           bag.ToCpp(), value.ToCpp());
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Member {
-    VarName name;
-    Type* type;
+  VarName name;
+  Type *type;
 
-    std::string ToCpp(FreshVariableSource* source) const;
+  std::string ToCpp(FreshVariableSource *source) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Method {
-    VarName name;
-    std::vector<std::pair<VarName, Type*>> arguments;
-    std::vector<Action*> body;
+  VarName name;
+  std::vector<std::pair<VarName, Type *>> arguments;
+  std::vector<Action *> body;
 
-    explicit Method(VarName name_) : name(name_), arguments(), body() {}
+  explicit Method(VarName name_) : name(name_), arguments(), body() {}
 
-    std::string ToCpp(FreshVariableSource* source) const;
+  std::string ToCpp(FreshVariableSource *source) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct DataStructure {
-    std::string name;
-    std::vector<TypeParameter> type_parameters;
-    std::vector<Member> members;
-    std::vector<Method> methods;
+  std::string name;
+  std::vector<TypeParameter> type_parameters;
+  std::vector<Member> members;
+  std::vector<Method> methods;
 
-    explicit DataStructure(std::string name_)
-        : name(name_), type_parameters(), members(), methods() {}
+  explicit DataStructure(std::string name_)
+      : name(name_), type_parameters(), members(), methods() {}
 
-    std::string ToCpp(FreshVariableSource* source) const;
+  std::string ToCpp(FreshVariableSource *source) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_AST_H_
+#endif // RDSS_AST_H_

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -24,337 +24,302 @@
 namespace rdss {
 
 struct RelationCode {
-    int32_t member;
-    int32_t insertion_method;
-    int32_t deletion_method;
+  int32_t member;
+  int32_t insertion_method;
+  int32_t deletion_method;
 };
 
 namespace {
 
-template<typename T>
-std::vector<T>& operator+=(std::vector<T>& a, const std::vector<T>& b) {
-    a.insert(a.end(), b.begin(), b.end());
-    return a;
+template <typename T>
+std::vector<T> &operator+=(std::vector<T> &a, const std::vector<T> &b) {
+  a.insert(a.end(), b.begin(), b.end());
+  return a;
 }
 
-}  // namespace
+} // namespace
 
-std::vector<Attr> LHSIndices(const JoinOn& join_on) {
-    std::vector<Attr> result;
-    for (auto [i, j] : join_on) {
-        result.push_back(i);
-    }
-    return result;
+std::vector<Attr> LHSIndices(const JoinOn &join_on) {
+  std::vector<Attr> result;
+  for (auto [i, j] : join_on) {
+    result.push_back(i);
+  }
+  return result;
 }
 
-std::vector<Attr> RHSIndices(const JoinOn& join_on) {
-    std::vector<Attr> result;
-    for (auto [i, j] : join_on) {
-        result.push_back(j);
-    }
-    return result;
+std::vector<Attr> RHSIndices(const JoinOn &join_on) {
+  std::vector<Attr> result;
+  for (auto [i, j] : join_on) {
+    result.push_back(j);
+  }
+  return result;
 }
 
-using TypingContext = absl::btree_map<Relation*, Type*>;
+using TypingContext = absl::btree_map<Relation *, Type *>;
 
 struct Codegen {
-    Codegen(absl::string_view name,
-            FreshVariableSource* source_,
-            const TypingContext& typing_context_)
-        : table_relations()
-        , view_relations()
-        , ds(std::string(name))
-        , source(source_)
-        , typing_context(typing_context_) {}
+  Codegen(absl::string_view name, FreshVariableSource *source_,
+          const TypingContext &typing_context_)
+      : table_relations(), view_relations(), ds(std::string(name)),
+        source(source_), typing_context(typing_context_) {}
 
-    absl::btree_map<std::string, RelationCode> table_relations;
-    absl::btree_map<Relation*, RelationCode> view_relations;
-    DataStructure ds;
-    FreshVariableSource* source;
-    TypingContext typing_context;
+  absl::btree_map<std::string, RelationCode> table_relations;
+  absl::btree_map<Relation *, RelationCode> view_relations;
+  DataStructure ds;
+  FreshVariableSource *source;
+  TypingContext typing_context;
 
-    Member* MemberOfTable(absl::string_view name) {
-        return &ds.members.at(table_relations.at(name).member);
+  Member *MemberOfTable(absl::string_view name) {
+    return &ds.members.at(table_relations.at(name).member);
+  }
+
+  Member *MemberOfView(Relation *rel) {
+    return &ds.members.at(view_relations.at(rel).member);
+  }
+
+  Method *InsertionOfTable(absl::string_view name) {
+    return &ds.methods.at(table_relations.at(name).insertion_method);
+  }
+
+  Method *InsertionOfView(Relation *rel) {
+    return &ds.methods.at(view_relations.at(rel).insertion_method);
+  }
+
+  Method *DeletionOfTable(absl::string_view name) {
+    return &ds.methods.at(table_relations.at(name).deletion_method);
+  }
+
+  Method *DeletionOfView(Relation *rel) {
+    return &ds.methods.at(view_relations.at(rel).deletion_method);
+  }
+
+  RelationCode SimpleRelationCode(absl::string_view name, Type *type) {
+    RelationCode rel_code;
+
+    {
+      int32_t member = ds.members.size();
+      ds.members.push_back(Member{VarName(name), new TypeHashSet(type)});
+      rel_code.member = member;
     }
 
-    Member* MemberOfView(Relation* rel) {
-        return &ds.members.at(view_relations.at(rel).member);
+    {
+      int32_t insertion_method = ds.methods.size();
+      ds.methods.push_back(Method(VarName(absl::StrCat(name, "_insert"))));
+      ds.methods.back().arguments.push_back({VarName("tuple"), type});
+      ds.methods.back().body.push_back(
+          new ActionInsertHashSet(VarName(name), VarName("tuple")));
+      rel_code.insertion_method = insertion_method;
     }
 
-    Method* InsertionOfTable(absl::string_view name) {
-        return &ds.methods.at(table_relations.at(name).insertion_method);
+    {
+      int32_t deletion_method = ds.methods.size();
+      ds.methods.push_back(Method(VarName(absl::StrCat(name, "_delete"))));
+      ds.methods.back().arguments.push_back({VarName("tuple"), type});
+      ds.methods.back().body.push_back(
+          new ActionDeleteHashSet(VarName(name), VarName("tuple")));
+      rel_code.deletion_method = deletion_method;
     }
 
-    Method* InsertionOfView(Relation* rel) {
-        return &ds.methods.at(view_relations.at(rel).insertion_method);
+    return rel_code;
+  }
+
+  std::pair<std::vector<Action *>, Type *>
+  FilterTuple(VarName output, std::pair<VarName, Type *> tuple,
+              absl::Span<int32_t const> element_indices) {
+    std::vector<Action *> result;
+    std::vector<Type *> type_vector;
+    std::vector<std::pair<VarName, Type *>> restricted_elements;
+    for (int32_t i : element_indices) {
+      VarName elem = source->Fresh();
+      result.push_back(new ActionIndexRow(elem, tuple.first, i));
+      Type *type =
+          DynamicCast<Type, TypeRow>(tuple.second).value()->elements.at(i);
+      type_vector.push_back(type);
+      restricted_elements.push_back({elem, type});
+    }
+    result.push_back(new ActionCreateRow(output, restricted_elements));
+    return {result, new TypeRow(type_vector)};
+  }
+
+  absl::Status Run(Relation *rel) {
+    if (view_relations.contains(rel)) {
+      return absl::OkStatus();
     }
 
-    Method* DeletionOfTable(absl::string_view name) {
-        return &ds.methods.at(table_relations.at(name).deletion_method);
-    }
+    if (auto r = DynamicCast<Relation, RelationReference>(rel)) {
+      std::string name = r.value()->name;
+      Type *type = typing_context.at(rel);
 
-    Method* DeletionOfView(Relation* rel) {
-        return &ds.methods.at(view_relations.at(rel).deletion_method);
-    }
-
-    RelationCode SimpleRelationCode(absl::string_view name,
-                                    Type* type) {
-        RelationCode rel_code;
-
-        {
-            int32_t member = ds.members.size();
-            ds.members.push_back(
-                Member { VarName(name), new TypeHashSet(type) });
-            rel_code.member = member;
-        }
-
-        {
-            int32_t insertion_method = ds.methods.size();
-            ds.methods.push_back(
-                Method(VarName(absl::StrCat(name, "_insert"))));
-            ds.methods.back().arguments.push_back(
-                { VarName("tuple"), type });
-            ds.methods.back().body.push_back(
-                new ActionInsertHashSet(VarName(name), VarName("tuple")));
-            rel_code.insertion_method = insertion_method;
-        }
-
-        {
-            int32_t deletion_method = ds.methods.size();
-            ds.methods.push_back(
-                Method(VarName(absl::StrCat(name, "_delete"))));
-            ds.methods.back().arguments.push_back(
-                { VarName("tuple"), type });
-            ds.methods.back().body.push_back(
-                new ActionDeleteHashSet(VarName(name), VarName("tuple")));
-            rel_code.deletion_method = deletion_method;
-        }
-
-        return rel_code;
-    }
-
-    std::pair<std::vector<Action*>, Type*>
-    FilterTuple(VarName output,
-                std::pair<VarName, Type*> tuple,
-                absl::Span<int32_t const> element_indices) {
-        std::vector<Action*> result;
-        std::vector<Type*> type_vector;
-        std::vector<std::pair<VarName, Type*>> restricted_elements;
-        for (int32_t i : element_indices) {
-            VarName elem = source->Fresh();
-            result.push_back(new ActionIndexRow(elem, tuple.first, i));
-            Type* type =
-                DynamicCast<Type, TypeRow>(tuple.second)
-                .value()->elements.at(i);
-            type_vector.push_back(type);
-            restricted_elements.push_back({elem, type});
-        }
-        result.push_back(new ActionCreateRow(output, restricted_elements));
-        return {result, new TypeRow(type_vector)};
-    }
-
-    absl::Status Run(Relation* rel) {
-        if (view_relations.contains(rel)) {
-            return absl::OkStatus();
-        }
-
-        if (auto r = DynamicCast<Relation, RelationReference>(rel)) {
-            std::string name = r.value()->name;
-            Type* type = typing_context.at(rel);
-
-            if (table_relations.contains(name)) {
-                view_relations[rel] = table_relations.at(name);
-                return absl::OkStatus();
-            }
-
-            RelationCode rel_code = SimpleRelationCode(name, type);
-
-            table_relations[name] = rel_code;
-            view_relations[rel] = rel_code;
-        } else if (auto r = DynamicCast<Relation, RelationJoin>(rel)) {
-            // FIXME: implement this case
-        } else if (auto r = DynamicCast<Relation, RelationSemijoin>(rel)) {
-            VarName rel_name = source->Fresh();
-            Type* rel_type = typing_context.at(rel);
-
-            view_relations[rel] = SimpleRelationCode(rel_name.name, rel_type);
-
-            auto lhs = r.value()->lhs;
-            auto rhs = r.value()->rhs;
-            auto join_on = r.value()->attributes;
-
-            RETURN_IF_ERROR(this->Run(lhs));
-            RETURN_IF_ERROR(this->Run(rhs));
-
-            {
-                VarName restricted_lhs = source->Fresh();
-
-                InsertionOfView(lhs)->body +=
-                    FilterTuple(restricted_lhs,
-                                {VarName("tuple"), typing_context.at(lhs)},
-                                LHSIndices(join_on)).first;
-
-                InsertionOfView(lhs)->body.push_back(
-                    new ActionIterateOverHashSet {
-                        MemberOfView(rhs)->name,
-                        [=, this](VarName tuple) -> std::vector<Action*> {
-                            std::vector<Action*> result;
-
-                            VarName restricted_rhs = source->Fresh();
-
-                            result +=
-                                FilterTuple(restricted_rhs,
-                                            {tuple, typing_context.at(rhs)},
-                                            RHSIndices(join_on)).first;
-
-                            result.push_back(
-                                new ActionIfEquals(
-                                    {{restricted_lhs, restricted_rhs}},
-                                    {
-                                        new ActionInvoke(
-                                            InsertionOfView(rel)->name,
-                                            {VarName("tuple")})
-                                    }));
-                            return result;
-                        }
-                    });
-            }
-
-            {
-                VarName restricted_rhs = source->Fresh();
-
-                InsertionOfView(rhs)->body +=
-                    FilterTuple(restricted_rhs,
-                                {VarName("tuple"), typing_context.at(rhs)},
-                                RHSIndices(join_on)).first;
-
-                InsertionOfView(rhs)->body.push_back(
-                    new ActionIterateOverHashSet {
-                        MemberOfView(lhs)->name,
-                        [=, this](VarName tuple) -> std::vector<Action*> {
-                            std::vector<Action*> result;
-
-                            VarName restricted_lhs = source->Fresh();
-
-                            result +=
-                                FilterTuple(restricted_lhs,
-                                            {tuple, typing_context.at(lhs)},
-                                            LHSIndices(join_on)).first;
-
-                            result.push_back(
-                                new ActionIfEquals(
-                                    {{restricted_lhs, restricted_rhs}},
-                                    {
-                                        new ActionInvoke(
-                                            InsertionOfView(rel)->name,
-                                            {tuple})
-                                    }));
-                            return result;
-                        }
-                    });
-            }
-
-            // FIXME: implement deletion for semijoins
-        } else if (auto r = DynamicCast<Relation, RelationUnion>(rel)) {
-            view_relations[rel] =
-                SimpleRelationCode(source->Fresh().name,
-                                   typing_context.at(rel));
-
-            auto lhs = r.value()->lhs;
-            auto rhs = r.value()->rhs;
-
-            RETURN_IF_ERROR(this->Run(lhs));
-            RETURN_IF_ERROR(this->Run(rhs));
-
-            InsertionOfView(lhs)->body.push_back(
-                new ActionInvoke(InsertionOfView(rel)->name,
-                                 {VarName("tuple")}));
-
-            InsertionOfView(rhs)->body.push_back(
-                new ActionInvoke(InsertionOfView(rel)->name,
-                                 {VarName("tuple")}));
-
-            // FIXME: implement deletions
-        } else if (auto r = DynamicCast<Relation, RelationDifference>(rel)) {
-            view_relations[rel] =
-                SimpleRelationCode(source->Fresh().name,
-                                   typing_context.at(rel));
-
-            auto lhs = r.value()->lhs;
-            auto rhs = r.value()->rhs;
-
-            RETURN_IF_ERROR(this->Run(lhs));
-            RETURN_IF_ERROR(this->Run(rhs));
-
-            InsertionOfView(lhs)->body.push_back(
-                new ActionInvoke(InsertionOfView(rel)->name,
-                                 {VarName("tuple")}));
-
-            InsertionOfView(rhs)->body.push_back(
-                new ActionInvoke(DeletionOfView(rel)->name,
-                                 {VarName("tuple")}));
-
-            DeletionOfView(lhs)->body.push_back(
-                new ActionInvoke(DeletionOfView(rel)->name,
-                                 {VarName("tuple")}));
-
-            auto contains_var = source->Fresh();
-            auto true_var = source->Fresh();
-            DeletionOfView(rhs)->body += {
-                new ActionContainsHashSet(contains_var,
-                                          MemberOfView(lhs)->name,
-                                          {VarName("tuple")}),
-                new ActionAssignConstant(true_var, "true"),
-                new ActionIfEquals({{contains_var, true_var}},
-                                   {new ActionInvoke(InsertionOfView(rel)->name,
-                                                     {VarName("tuple")})})
-            };
-        } else if (auto r = DynamicCast<Relation, RelationSelect>(rel)) {
-            // FIXME: implement this case
-        } else if (auto r = DynamicCast<Relation, RelationMap>(rel)) {
-            // FIXME: implement this case
-        } else if (auto r = DynamicCast<Relation, RelationView>(rel)) {
-            view_relations[rel] =
-                SimpleRelationCode(source->Fresh().name,
-                                   typing_context.at(rel));
-
-            auto perm = r.value()->rel.perm;
-            auto underlying = r.value()->rel.rel;
-
-            RETURN_IF_ERROR(this->Run(underlying));
-
-            std::vector<std::pair<VarName, Type*>> viewed_elements;
-            viewed_elements.resize(r.value()->rel.Arity(),
-                                   {VarName(""), nullptr});
-            int32_t i = 0;
-            for (std::optional<Attr> attr_maybe : perm) {
-                if (attr_maybe.has_value()) {
-                    VarName elem = source->Fresh();
-                    InsertionOfView(underlying)->body.push_back(
-                        new ActionIndexRow(elem, VarName("tuple"), i));
-                    Type* type =
-                        DynamicCast<Type, TypeRow>(typing_context.at(underlying))
-                        .value()->elements.at(i);
-                    viewed_elements.at(attr_maybe.value()) = {elem, type};
-                }
-                i++;
-            }
-            VarName output = source->Fresh();
-            InsertionOfView(underlying)->body += {
-                new ActionCreateRow(output, viewed_elements),
-                new ActionInvoke(InsertionOfView(rel)->name, {output})
-            };
-
-            // FIXME: implement deletions for views
-        } else {
-            return absl::InternalError(
-                "If this is reached, a new relation op has been added but no "
-                "case was added to the codegen. Please add one.");
-        }
+      if (table_relations.contains(name)) {
+        view_relations[rel] = table_relations.at(name);
         return absl::OkStatus();
+      }
+
+      RelationCode rel_code = SimpleRelationCode(name, type);
+
+      table_relations[name] = rel_code;
+      view_relations[rel] = rel_code;
+    } else if (auto r = DynamicCast<Relation, RelationJoin>(rel)) {
+      // FIXME: implement this case
+    } else if (auto r = DynamicCast<Relation, RelationSemijoin>(rel)) {
+      VarName rel_name = source->Fresh();
+      Type *rel_type = typing_context.at(rel);
+
+      view_relations[rel] = SimpleRelationCode(rel_name.name, rel_type);
+
+      auto lhs = r.value()->lhs;
+      auto rhs = r.value()->rhs;
+      auto join_on = r.value()->attributes;
+
+      RETURN_IF_ERROR(this->Run(lhs));
+      RETURN_IF_ERROR(this->Run(rhs));
+
+      {
+        VarName restricted_lhs = source->Fresh();
+
+        InsertionOfView(lhs)->body +=
+            FilterTuple(restricted_lhs,
+                        {VarName("tuple"), typing_context.at(lhs)},
+                        LHSIndices(join_on))
+                .first;
+
+        InsertionOfView(lhs)->body.push_back(new ActionIterateOverHashSet{
+            MemberOfView(rhs)->name,
+            [=, this](VarName tuple) -> std::vector<Action *> {
+              std::vector<Action *> result;
+
+              VarName restricted_rhs = source->Fresh();
+
+              result +=
+                  FilterTuple(restricted_rhs, {tuple, typing_context.at(rhs)},
+                              RHSIndices(join_on))
+                      .first;
+
+              result.push_back(new ActionIfEquals(
+                  {{restricted_lhs, restricted_rhs}},
+                  {new ActionInvoke(InsertionOfView(rel)->name,
+                                    {VarName("tuple")})}));
+              return result;
+            }});
+      }
+
+      {
+        VarName restricted_rhs = source->Fresh();
+
+        InsertionOfView(rhs)->body +=
+            FilterTuple(restricted_rhs,
+                        {VarName("tuple"), typing_context.at(rhs)},
+                        RHSIndices(join_on))
+                .first;
+
+        InsertionOfView(rhs)->body.push_back(new ActionIterateOverHashSet{
+            MemberOfView(lhs)->name,
+            [=, this](VarName tuple) -> std::vector<Action *> {
+              std::vector<Action *> result;
+
+              VarName restricted_lhs = source->Fresh();
+
+              result +=
+                  FilterTuple(restricted_lhs, {tuple, typing_context.at(lhs)},
+                              LHSIndices(join_on))
+                      .first;
+
+              result.push_back(new ActionIfEquals(
+                  {{restricted_lhs, restricted_rhs}},
+                  {new ActionInvoke(InsertionOfView(rel)->name, {tuple})}));
+              return result;
+            }});
+      }
+
+      // FIXME: implement deletion for semijoins
+    } else if (auto r = DynamicCast<Relation, RelationUnion>(rel)) {
+      view_relations[rel] =
+          SimpleRelationCode(source->Fresh().name, typing_context.at(rel));
+
+      auto lhs = r.value()->lhs;
+      auto rhs = r.value()->rhs;
+
+      RETURN_IF_ERROR(this->Run(lhs));
+      RETURN_IF_ERROR(this->Run(rhs));
+
+      InsertionOfView(lhs)->body.push_back(
+          new ActionInvoke(InsertionOfView(rel)->name, {VarName("tuple")}));
+
+      InsertionOfView(rhs)->body.push_back(
+          new ActionInvoke(InsertionOfView(rel)->name, {VarName("tuple")}));
+
+      // FIXME: implement deletions
+    } else if (auto r = DynamicCast<Relation, RelationDifference>(rel)) {
+      view_relations[rel] =
+          SimpleRelationCode(source->Fresh().name, typing_context.at(rel));
+
+      auto lhs = r.value()->lhs;
+      auto rhs = r.value()->rhs;
+
+      RETURN_IF_ERROR(this->Run(lhs));
+      RETURN_IF_ERROR(this->Run(rhs));
+
+      InsertionOfView(lhs)->body.push_back(
+          new ActionInvoke(InsertionOfView(rel)->name, {VarName("tuple")}));
+
+      InsertionOfView(rhs)->body.push_back(
+          new ActionInvoke(DeletionOfView(rel)->name, {VarName("tuple")}));
+
+      DeletionOfView(lhs)->body.push_back(
+          new ActionInvoke(DeletionOfView(rel)->name, {VarName("tuple")}));
+
+      auto contains_var = source->Fresh();
+      auto true_var = source->Fresh();
+      DeletionOfView(rhs)->body +=
+          {new ActionContainsHashSet(contains_var, MemberOfView(lhs)->name,
+                                     {VarName("tuple")}),
+           new ActionAssignConstant(true_var, "true"),
+           new ActionIfEquals({{contains_var, true_var}},
+                              {new ActionInvoke(InsertionOfView(rel)->name,
+                                                {VarName("tuple")})})};
+    } else if (auto r = DynamicCast<Relation, RelationSelect>(rel)) {
+      // FIXME: implement this case
+    } else if (auto r = DynamicCast<Relation, RelationMap>(rel)) {
+      // FIXME: implement this case
+    } else if (auto r = DynamicCast<Relation, RelationView>(rel)) {
+      view_relations[rel] =
+          SimpleRelationCode(source->Fresh().name, typing_context.at(rel));
+
+      auto perm = r.value()->rel.perm;
+      auto underlying = r.value()->rel.rel;
+
+      RETURN_IF_ERROR(this->Run(underlying));
+
+      std::vector<std::pair<VarName, Type *>> viewed_elements;
+      viewed_elements.resize(r.value()->rel.Arity(), {VarName(""), nullptr});
+      int32_t i = 0;
+      for (std::optional<Attr> attr_maybe : perm) {
+        if (attr_maybe.has_value()) {
+          VarName elem = source->Fresh();
+          InsertionOfView(underlying)
+              ->body.push_back(new ActionIndexRow(elem, VarName("tuple"), i));
+          Type *type = DynamicCast<Type, TypeRow>(typing_context.at(underlying))
+                           .value()
+                           ->elements.at(i);
+          viewed_elements.at(attr_maybe.value()) = {elem, type};
+        }
+        i++;
+      }
+      VarName output = source->Fresh();
+      InsertionOfView(underlying)->body +=
+          {new ActionCreateRow(output, viewed_elements),
+           new ActionInvoke(InsertionOfView(rel)->name, {output})};
+
+      // FIXME: implement deletions for views
+    } else {
+      return absl::InternalError(
+          "If this is reached, a new relation op has been added but no "
+          "case was added to the codegen. Please add one.");
     }
+    return absl::OkStatus();
+  }
 };
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_CODEGEN_H_
+#endif // RDSS_CODEGEN_H_

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -18,55 +18,52 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <string>
 #include <filesystem>
+#include <string>
 
 #include <absl/status/status.h>
 #include <absl/status/statusor.h>
 
 namespace rdss {
 
-absl::Status ErrNoToStatusWithFilename(
-    int errno_value,
-    const std::filesystem::path& file_name
-) {
-    std::stringstream ss;
+absl::Status ErrNoToStatusWithFilename(int errno_value,
+                                       const std::filesystem::path &file_name) {
+  std::stringstream ss;
 
-    ss << "Error Code: " << errno_value;
-    ss << "\nPath was: " << file_name << "\n";
-    // TODO return an actual error
-    return absl::UnknownError(ss.str());
+  ss << "Error Code: " << errno_value;
+  ss << "\nPath was: " << file_name << "\n";
+  // TODO return an actual error
+  return absl::UnknownError(ss.str());
 }
 
-absl::StatusOr<std::string> GetFileContents(
-    const std::filesystem::path& file_name
-) {
-    // Use POSIX C APIs instead of C++ iostreams to avoid exceptions.
-    std::string result;
+absl::StatusOr<std::string>
+GetFileContents(const std::filesystem::path &file_name) {
+  // Use POSIX C APIs instead of C++ iostreams to avoid exceptions.
+  std::string result;
 
-    int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
-    if (fd == -1) {
-        return ErrNoToStatusWithFilename(errno, file_name);
-    }
+  int fd = open(file_name.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd == -1) {
+    return ErrNoToStatusWithFilename(errno, file_name);
+  }
 
-    char buf[4096];
-    while (ssize_t n = read(fd, buf, sizeof(buf))) {
-        if (n < 0) {
-            if (errno == EAGAIN) {
-                continue;
-            }
-            close(fd);
-            return ErrNoToStatusWithFilename(errno, file_name);
-        }
-        result.append(buf, n);
+  char buf[4096];
+  while (ssize_t n = read(fd, buf, sizeof(buf))) {
+    if (n < 0) {
+      if (errno == EAGAIN) {
+        continue;
+      }
+      close(fd);
+      return ErrNoToStatusWithFilename(errno, file_name);
     }
+    result.append(buf, n);
+  }
 
-    if (close(fd) != 0) {
-        return ErrNoToStatusWithFilename(errno, file_name);
-    }
-    return std::move(result);
+  if (close(fd) != 0) {
+    return ErrNoToStatusWithFilename(errno, file_name);
+  }
+  return std::move(result);
 }
 
 } // namespace rdss
 
-#endif  // RDSS_FILESYSTEM_H_
+#endif // RDSS_FILESYSTEM_H_

--- a/src/ghd.hpp
+++ b/src/ghd.hpp
@@ -42,701 +42,682 @@ namespace rdss {
 
 using HyperedgeId = int32_t;
 
-template<typename V>
-class Hypergraph {
+template <typename V> class Hypergraph {
 public:
-    void AddVertex(const V& vertex) {
-        this->vertex_to_hyperedge[vertex];
-    }
+  void AddVertex(const V &vertex) { this->vertex_to_hyperedge[vertex]; }
 
-    HyperedgeId AddEdge() {
-        HyperedgeId result = this->hyperedges.size();
-        this->hyperedges.push_back(Hyperedge { absl::flat_hash_set<V>() });
-        return result;
-    }
+  HyperedgeId AddEdge() {
+    HyperedgeId result = this->hyperedges.size();
+    this->hyperedges.push_back(Hyperedge{absl::flat_hash_set<V>()});
+    return result;
+  }
 
-    bool AddVertexToEdge(const V& vertex, HyperedgeId edge) {
-        if (!this->vertex_to_hyperedge.contains(vertex)) {
-            return false;
-        }
-        if (edge >= this->hyperedges.size()) {
-            return false;
-        }
-        this->vertex_to_hyperedge[vertex].insert(edge);
-        this->hyperedges[edge].vertices.insert(vertex);
-        return true;
+  bool AddVertexToEdge(const V &vertex, HyperedgeId edge) {
+    if (!this->vertex_to_hyperedge.contains(vertex)) {
+      return false;
     }
+    if (edge >= this->hyperedges.size()) {
+      return false;
+    }
+    this->vertex_to_hyperedge[vertex].insert(edge);
+    this->hyperedges[edge].vertices.insert(vertex);
+    return true;
+  }
 
-    absl::optional<absl::flat_hash_set<HyperedgeId>>
-    EdgesIncidentOnVertex(const V& vertex) const {
-        if (!this->vertex_to_hyperedge.contains(vertex)) {
-            return absl::nullopt;
-        }
-        return this->vertex_to_hyperedge.at(vertex);
+  absl::optional<absl::flat_hash_set<HyperedgeId>>
+  EdgesIncidentOnVertex(const V &vertex) const {
+    if (!this->vertex_to_hyperedge.contains(vertex)) {
+      return absl::nullopt;
     }
+    return this->vertex_to_hyperedge.at(vertex);
+  }
 
-    absl::optional<absl::flat_hash_set<V>>
-    VerticesInEdge(HyperedgeId edge) const {
-        if (edge >= this->hyperedges.size()) {
-            return absl::nullopt;
-        }
-        return this->hyperedges.at(edge).vertices;
+  absl::optional<absl::flat_hash_set<V>>
+  VerticesInEdge(HyperedgeId edge) const {
+    if (edge >= this->hyperedges.size()) {
+      return absl::nullopt;
     }
+    return this->hyperedges.at(edge).vertices;
+  }
 
-    absl::flat_hash_set<V> AllVertices() const {
-        absl::flat_hash_set<V> result;
-        for (const auto& [key, value] : this->vertex_to_hyperedge) {
-            result.insert(key);
-        }
-        return result;
+  absl::flat_hash_set<V> AllVertices() const {
+    absl::flat_hash_set<V> result;
+    for (const auto &[key, value] : this->vertex_to_hyperedge) {
+      result.insert(key);
     }
+    return result;
+  }
 
-    std::vector<HyperedgeId> AllEdges() const {
-        std::vector<HyperedgeId> result;
-        for (int32_t i = 0; i < this->hyperedges.size(); i++) {
-            if (!this->hyperedges.at(i).vertices.empty()) {
-                result.push_back(i);
-            }
-        }
-        return result;
+  std::vector<HyperedgeId> AllEdges() const {
+    std::vector<HyperedgeId> result;
+    for (int32_t i = 0; i < this->hyperedges.size(); i++) {
+      if (!this->hyperedges.at(i).vertices.empty()) {
+        result.push_back(i);
+      }
     }
+    return result;
+  }
 
-    int32_t NumVertices() const {
-        return this->vertex_to_hyperedge.size();
-    }
+  int32_t NumVertices() const { return this->vertex_to_hyperedge.size(); }
 
-    int32_t NumEdges() const {
-        return this->hyperedges.size();
-    }
+  int32_t NumEdges() const { return this->hyperedges.size(); }
 
-    void DeleteVertex(const V& vertex) {
-        if (auto edges = EdgesIncidentOnVertex(vertex)) {
-            for (const auto& edge : *edges) {
-                this->hyperedges.at(edge).vertices.erase(vertex);
-            }
-            this->vertex_to_hyperedge.erase(vertex);
-        }
+  void DeleteVertex(const V &vertex) {
+    if (auto edges = EdgesIncidentOnVertex(vertex)) {
+      for (const auto &edge : *edges) {
+        this->hyperedges.at(edge).vertices.erase(vertex);
+      }
+      this->vertex_to_hyperedge.erase(vertex);
     }
+  }
 
-    void DeleteEdge(HyperedgeId edge) {
-        if (auto vertices = VerticesInEdge(edge)) {
-            for (const auto& vertex : *vertices) {
-                this->vertex_to_hyperedge.at(vertex).erase(edge);
-            }
-            this->hyperedges.at(edge) = Hyperedge { {} };
-        }
+  void DeleteEdge(HyperedgeId edge) {
+    if (auto vertices = VerticesInEdge(edge)) {
+      for (const auto &vertex : *vertices) {
+        this->vertex_to_hyperedge.at(vertex).erase(edge);
+      }
+      this->hyperedges.at(edge) = Hyperedge{{}};
     }
+  }
 
-    void Print() const {
-        std::cerr << "([";
-        for (const Hyperedge& edge : this->hyperedges) {
-            std::cerr << "{";
-            for (const V& vertex : edge.vertices) {
-                std::cerr << vertex << ",";
-            }
-            std::cerr << "},";
-        }
-        std::cerr << "],{";
-        for (const auto& [vertex, edges] : this->vertex_to_hyperedge) {
-            std::cerr << vertex << " -> {";
-            for (HyperedgeId edge : edges) {
-                std::cerr << edge << ",";
-            }
-            std::cerr << "},";
-        }
-        std::cerr << "})\n";
+  void Print() const {
+    std::cerr << "([";
+    for (const Hyperedge &edge : this->hyperedges) {
+      std::cerr << "{";
+      for (const V &vertex : edge.vertices) {
+        std::cerr << vertex << ",";
+      }
+      std::cerr << "},";
     }
+    std::cerr << "],{";
+    for (const auto &[vertex, edges] : this->vertex_to_hyperedge) {
+      std::cerr << vertex << " -> {";
+      for (HyperedgeId edge : edges) {
+        std::cerr << edge << ",";
+      }
+      std::cerr << "},";
+    }
+    std::cerr << "})\n";
+  }
 
 private:
-    struct Hyperedge {
-        absl::flat_hash_set<V> vertices;
-    };
+  struct Hyperedge {
+    absl::flat_hash_set<V> vertices;
+  };
 
-    std::vector<Hyperedge> hyperedges;
-    absl::flat_hash_map<V, absl::flat_hash_set<HyperedgeId>> vertex_to_hyperedge;
+  std::vector<Hyperedge> hyperedges;
+  absl::flat_hash_map<V, absl::flat_hash_set<HyperedgeId>> vertex_to_hyperedge;
 };
 
 using NodeId = int32_t;
 
-template<typename Value>
-struct Digraph {
-    std::vector<Value> node_values;
-    absl::flat_hash_map<NodeId, absl::flat_hash_set<NodeId>> edges_out_of;
+template <typename Value> struct Digraph {
+  std::vector<Value> node_values;
+  absl::flat_hash_map<NodeId, absl::flat_hash_set<NodeId>> edges_out_of;
 
-    absl::flat_hash_set<NodeId> roots;
+  absl::flat_hash_set<NodeId> roots;
 
-    NodeId AddVertex(const Value& value) {
-        int32_t result = node_values.size();
-        node_values.push_back(value);
-        edges_out_of[result];
-        roots.insert(result);
-        return result;
+  NodeId AddVertex(const Value &value) {
+    int32_t result = node_values.size();
+    node_values.push_back(value);
+    edges_out_of[result];
+    roots.insert(result);
+    return result;
+  }
+
+  bool AddEdge(NodeId x, NodeId y) {
+    if (!edges_out_of.contains(x)) {
+      return false;
     }
 
-    bool AddEdge(NodeId x, NodeId y) {
-        if (!edges_out_of.contains(x)) {
-            return false;
-        }
-
-        if (!edges_out_of.contains(y)) {
-            return false;
-        }
-
-        edges_out_of.at(x).insert(y);
-        roots.erase(y);
-
-        return true;
+    if (!edges_out_of.contains(y)) {
+      return false;
     }
 
-    const absl::flat_hash_set<NodeId>& Roots() const {
-        return roots;
-    }
-
-    const absl::flat_hash_set<NodeId>& EdgesOutOf(NodeId node) const {
-        return edges_out_of.at(node);
-    }
-
-    std::vector<NodeId> AllNodes() const {
-        std::vector<NodeId> result;
-        for (int32_t i = 0; i < node_values.size(); i++) {
-            result.push_back(i);
-        }
-        return result;
-    }
-
-    Value& GetValue(NodeId node) {
-        return node_values.at(node);
-    }
-
-    const Value& GetValue(NodeId node) const {
-        return node_values.at(node);
-    }
-};
-
-template <typename V, typename E>
-struct Tree {
-    V element;
-    std::vector<std::pair<Tree, E>> children;
-
-    std::string Print(std::function<std::string(const V&)> callback) const {
-        std::stringstream ss;
-        ss << "{ \"element\": " << callback(this->element) << ","
-           << "  \"children\": [ ";
-        std::vector<std::string> cs;
-        for (const auto& child : this->children) {
-            cs.push_back(child.Print(callback));
-        }
-        ss << absl::StrJoin(cs, ", ") << " ] }";
-
-        return ss.str();
-    }
-};
-
-template <typename V>
-struct Bag {
-    absl::flat_hash_set<V> attributes;
-    absl::flat_hash_map<HyperedgeId, double> relations;
-    Bag() : attributes(), relations() {}
-};
-
-
-template <typename V>
-absl::optional<Tree<V, absl::monostate>> DigraphToTree(Digraph<V>& digraph) {
-    if (digraph.Roots().size() != 1) {
-        return absl::nullopt;
-    }
-
-    NodeId root = *(digraph.Roots().begin());
-
-    std::vector<std::pair<NodeId, Tree<V, absl::monostate>*>> active;
-    absl::flat_hash_set<NodeId> seen;
-
-    Tree<V, absl::monostate> tree { digraph.GetValue(root), { } };
-
-    active.push_back(std::pair<NodeId, Tree<V, absl::monostate>*>{ root, &tree });
-    while (!active.empty()) {
-        auto [source, parent] = active.back();
-        active.pop_back();
-        if (seen.contains(source)) {
-            return absl::nullopt;
-        }
-        seen.insert(source);
-
-        for (const auto& target : digraph.EdgesOutOf(source)) {
-            parent->children.push_back({
-                    Tree<V, absl::monostate> { digraph.GetValue(target), { } },
-                    absl::monostate()
-                });
-            // FIXME this is a dirty hack
-            parent->children.back().first.children.reserve(
-                digraph.EdgesOutOf(target).size());
-            active.push_back({ target, &parent->children.back().first });
-        }
-    }
-
-    return tree;
-}
-
-template <typename V>
-bool VerifyRunningIntersectionProperty(const Digraph<Bag<V>>& digraph) {
-    absl::flat_hash_set<V> all_attributes;
-
-    for (NodeId node : digraph.AllNodes()) {
-        for (auto attribute : digraph.GetValue(node).attributes) {
-            all_attributes.insert(attribute);
-        }
-    }
-
-    for (V attribute : all_attributes) {
-        absl::flat_hash_set<NodeId> contains_attribute;
-        for (NodeId node : digraph.AllNodes()) {
-            if (digraph.GetValue(node).attributes.contains(attribute)) {
-                contains_attribute.insert(node);
-            }
-        }
-        UnionFindMap<NodeId, absl::monostate> uf;
-
-        for (NodeId node : contains_attribute) {
-            uf.Insert(node, absl::monostate());
-        }
-
-        for (NodeId source : contains_attribute) {
-            for (NodeId target : digraph.EdgesOutOf(source)) {
-                if (contains_attribute.contains(target)) {
-                    uf.Union(source, target,
-                             [](absl::monostate, absl::monostate) {
-                                 return absl::monostate();
-                             });
-                }
-            }
-        }
-
-        if (uf.GetRepresentatives().size() != 1) {
-            return false;
-        }
-    }
+    edges_out_of.at(x).insert(y);
+    roots.erase(y);
 
     return true;
-}
+  }
 
-void LookupInModel(z3::model model,
-                   absl::string_view name,
-                   std::function<void(const z3::func_decl&)> callback) {
-    for (int32_t i = 0; i < model.size(); i++) {
-        if (model[i].name().str() == name) {
-            callback(model[i]);
-        }
+  const absl::flat_hash_set<NodeId> &Roots() const { return roots; }
+
+  const absl::flat_hash_set<NodeId> &EdgesOutOf(NodeId node) const {
+    return edges_out_of.at(node);
+  }
+
+  std::vector<NodeId> AllNodes() const {
+    std::vector<NodeId> result;
+    for (int32_t i = 0; i < node_values.size(); i++) {
+      result.push_back(i);
     }
+    return result;
+  }
+
+  Value &GetValue(NodeId node) { return node_values.at(node); }
+
+  const Value &GetValue(NodeId node) const { return node_values.at(node); }
+};
+
+template <typename V, typename E> struct Tree {
+  V element;
+  std::vector<std::pair<Tree, E>> children;
+
+  std::string Print(std::function<std::string(const V &)> callback) const {
+    std::stringstream ss;
+    ss << "{ \"element\": " << callback(this->element) << ","
+       << "  \"children\": [ ";
+    std::vector<std::string> cs;
+    for (const auto &child : this->children) {
+      cs.push_back(child.Print(callback));
+    }
+    ss << absl::StrJoin(cs, ", ") << " ] }";
+
+    return ss.str();
+  }
+};
+
+template <typename V> struct Bag {
+  absl::flat_hash_set<V> attributes;
+  absl::flat_hash_map<HyperedgeId, double> relations;
+  Bag() : attributes(), relations() {}
+};
+
+template <typename V>
+absl::optional<Tree<V, absl::monostate>> DigraphToTree(Digraph<V> &digraph) {
+  if (digraph.Roots().size() != 1) {
+    return absl::nullopt;
+  }
+
+  NodeId root = *(digraph.Roots().begin());
+
+  std::vector<std::pair<NodeId, Tree<V, absl::monostate> *>> active;
+  absl::flat_hash_set<NodeId> seen;
+
+  Tree<V, absl::monostate> tree{digraph.GetValue(root), {}};
+
+  active.push_back(std::pair<NodeId, Tree<V, absl::monostate> *>{root, &tree});
+  while (!active.empty()) {
+    auto [source, parent] = active.back();
+    active.pop_back();
+    if (seen.contains(source)) {
+      return absl::nullopt;
+    }
+    seen.insert(source);
+
+    for (const auto &target : digraph.EdgesOutOf(source)) {
+      parent->children.push_back(
+          {Tree<V, absl::monostate>{digraph.GetValue(target), {}},
+           absl::monostate()});
+      // FIXME this is a dirty hack
+      parent->children.back().first.children.reserve(
+          digraph.EdgesOutOf(target).size());
+      active.push_back({target, &parent->children.back().first});
+    }
+  }
+
+  return tree;
 }
 
 template <typename V>
-struct FHD {
-    double fhw;
-    Tree<Bag<V>, absl::monostate> tree;
+bool VerifyRunningIntersectionProperty(const Digraph<Bag<V>> &digraph) {
+  absl::flat_hash_set<V> all_attributes;
+
+  for (NodeId node : digraph.AllNodes()) {
+    for (auto attribute : digraph.GetValue(node).attributes) {
+      all_attributes.insert(attribute);
+    }
+  }
+
+  for (V attribute : all_attributes) {
+    absl::flat_hash_set<NodeId> contains_attribute;
+    for (NodeId node : digraph.AllNodes()) {
+      if (digraph.GetValue(node).attributes.contains(attribute)) {
+        contains_attribute.insert(node);
+      }
+    }
+    UnionFindMap<NodeId, absl::monostate> uf;
+
+    for (NodeId node : contains_attribute) {
+      uf.Insert(node, absl::monostate());
+    }
+
+    for (NodeId source : contains_attribute) {
+      for (NodeId target : digraph.EdgesOutOf(source)) {
+        if (contains_attribute.contains(target)) {
+          uf.Union(source, target, [](absl::monostate, absl::monostate) {
+            return absl::monostate();
+          });
+        }
+      }
+    }
+
+    if (uf.GetRepresentatives().size() != 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void LookupInModel(z3::model model, absl::string_view name,
+                   std::function<void(const z3::func_decl &)> callback) {
+  for (int32_t i = 0; i < model.size(); i++) {
+    if (model[i].name().str() == name) {
+      callback(model[i]);
+    }
+  }
+}
+
+template <typename V> struct FHD {
+  double fhw;
+  Tree<Bag<V>, absl::monostate> tree;
 };
 
-template<typename V>
-absl::StatusOr<FHD<V>> ComputeFHD(const Hypergraph<V>& hypergraph) {
-    for (const V& vertex : hypergraph.AllVertices()) {
-        if (hypergraph.EdgesIncidentOnVertex(vertex).value().empty()) {
-            return absl::FailedPreconditionError("Detected vertex with no covering edges.");
+template <typename V>
+absl::StatusOr<FHD<V>> ComputeFHD(const Hypergraph<V> &hypergraph) {
+  for (const V &vertex : hypergraph.AllVertices()) {
+    if (hypergraph.EdgesIncidentOnVertex(vertex).value().empty()) {
+      return absl::FailedPreconditionError(
+          "Detected vertex with no covering edges.");
+    }
+  }
+
+  auto all_vertices = hypergraph.AllVertices();
+  std::vector<V> vertices_vec(all_vertices.begin(), all_vertices.end());
+  std::sort(vertices_vec.begin(), vertices_vec.end());
+
+  auto all_edges = hypergraph.AllEdges();
+  std::vector<HyperedgeId> edges_vec(all_edges.begin(), all_edges.end());
+  std::sort(edges_vec.begin(), edges_vec.end());
+
+  int32_t num_vertices = vertices_vec.size();
+  int32_t num_edges = edges_vec.size();
+
+  absl::flat_hash_map<V, int32_t> vertex_to_int;
+  for (int32_t i = 0; i < num_vertices; i++) {
+    vertex_to_int[vertices_vec[i]] = i;
+  }
+
+  absl::flat_hash_map<HyperedgeId, int32_t> edge_to_int;
+  for (int32_t i = 0; i < num_edges; i++) {
+    edge_to_int[edges_vec[i]] = i;
+  }
+
+  z3::context c;
+  // z3::solver s(c);
+  z3::optimize s(c);
+
+  z3::expr m = c.real_const("m");
+
+  s.add(m >= 1);
+
+  struct optional_expr {
+    absl::optional<z3::expr> value_;
+    optional_expr() : value_() {}
+    optional_expr(const z3::expr &expr) : value_(expr) {}
+    const z3::expr &value() { return value_.value(); }
+  };
+
+  optional_expr o_star[num_vertices][num_vertices];
+  optional_expr a[num_vertices][num_vertices];
+  optional_expr w[num_vertices][num_edges];
+
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t j = 0; j < num_vertices; j++) {
+      if (i < j) {
+        std::stringstream ss;
+        ss << "ostar_" << i << "_" << j;
+        std::string o_star_str = ss.str();
+
+        o_star[i][j] = c.bool_const(o_star_str.c_str());
+      }
+
+      {
+        std::stringstream ss;
+        ss << "a_" << i << "_" << j;
+        std::string a_str = ss.str();
+        a[i][j] = c.bool_const(a_str.c_str());
+      }
+    }
+  }
+
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t e = 0; e < num_edges; e++) {
+      std::stringstream ss;
+      ss << "w_" << i << "_" << e;
+      std::string w_str = ss.str();
+      w[i][e] = c.real_const(w_str.c_str());
+      s.add(w[i][e].value() <= 1);
+      s.add(w[i][e].value() >= 0);
+    }
+  }
+
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t j = 0; j < num_vertices; j++) {
+      if (j < i) {
+        o_star[i][j] = !o_star[j][i].value();
+      }
+    }
+  }
+
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t j = 0; j < num_vertices; j++) {
+      for (int32_t k = 0; k < num_vertices; k++) {
+        if ((i == j) || (i == k) || (j == k)) {
+          continue;
         }
+        s.add(!o_star[i][j].value() || !o_star[j][k].value() ||
+              o_star[i][k].value());
+      }
     }
+  }
 
-    auto all_vertices = hypergraph.AllVertices();
-    std::vector<V> vertices_vec(all_vertices.begin(), all_vertices.end());
-    std::sort(vertices_vec.begin(), vertices_vec.end());
+  for (auto edge : edges_vec) {
+    absl::flat_hash_set<V> vs = hypergraph.VerticesInEdge(edge).value();
+    for (const auto &x : vs) {
+      for (const auto &y : vs) {
+        auto i = vertex_to_int.at(x);
+        auto j = vertex_to_int.at(y);
 
-    auto all_edges = hypergraph.AllEdges();
-    std::vector<HyperedgeId> edges_vec(all_edges.begin(), all_edges.end());
-    std::sort(edges_vec.begin(), edges_vec.end());
-
-    int32_t num_vertices = vertices_vec.size();
-    int32_t num_edges = edges_vec.size();
-
-    absl::flat_hash_map<V, int32_t> vertex_to_int;
-    for (int32_t i = 0; i < num_vertices; i++) {
-        vertex_to_int[vertices_vec[i]] = i;
-    }
-
-    absl::flat_hash_map<HyperedgeId, int32_t> edge_to_int;
-    for (int32_t i = 0; i < num_edges; i++) {
-        edge_to_int[edges_vec[i]] = i;
-    }
-
-    z3::context c;
-    // z3::solver s(c);
-    z3::optimize s(c);
-
-    z3::expr m = c.real_const("m");
-
-    s.add(m >= 1);
-
-    struct optional_expr {
-        absl::optional<z3::expr> value_;
-        optional_expr() : value_() {}
-        optional_expr(const z3::expr& expr) : value_(expr) {}
-        const z3::expr& value() { return value_.value(); }
-    };
-
-    optional_expr o_star[num_vertices][num_vertices];
-    optional_expr a[num_vertices][num_vertices];
-    optional_expr w[num_vertices][num_edges];
-
-    for (int32_t i = 0; i < num_vertices; i++) {
-        for (int32_t j = 0; j < num_vertices; j++) {
-            if (i < j) {
-                std::stringstream ss;
-                ss << "ostar_" << i << "_" << j;
-                std::string o_star_str = ss.str();
-
-                o_star[i][j] = c.bool_const(o_star_str.c_str());
-            }
-
-            {
-                std::stringstream ss;
-                ss << "a_" << i << "_" << j;
-                std::string a_str = ss.str();
-                a[i][j] = c.bool_const(a_str.c_str());
-            }
+        if (i >= j) {
+          continue;
         }
+        s.add(o_star[j][i].value() || a[i][j].value());
+        s.add(o_star[i][j].value() || a[j][i].value());
+      }
     }
+  }
 
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t j = 0; j < num_vertices; j++) {
+      for (int32_t k = 0; k < num_vertices; k++) {
+        if ((i == j) || (i == k) || (j >= k)) {
+          continue;
+        }
+        s.add(!a[i][j].value() || !a[i][k].value() || o_star[k][j].value() ||
+              a[j][k].value());
+        s.add(!a[i][j].value() || !a[i][k].value() || o_star[j][k].value() ||
+              a[k][j].value());
+        s.add(!a[i][j].value() || !a[i][k].value() || a[j][k].value() ||
+              a[k][j].value());
+      }
+    }
+  }
+
+  for (int32_t i = 0; i < num_vertices; i++) {
+    s.add(!a[i][i].value());
+  }
+
+  {
     for (int32_t i = 0; i < num_vertices; i++) {
+      for (int32_t j = 0; j < num_vertices; j++) {
+        if (i == j) {
+          continue;
+        }
+        absl::optional<z3::expr> sum;
         for (int32_t e = 0; e < num_edges; e++) {
-            std::stringstream ss;
-            ss << "w_" << i << "_" << e;
-            std::string w_str = ss.str();
-            w[i][e] = c.real_const(w_str.c_str());
-            s.add(w[i][e].value() <= 1);
-            s.add(w[i][e].value() >= 0);
+          if (hypergraph.VerticesInEdge(edges_vec[e])
+                  .value()
+                  .contains(vertices_vec[j])) {
+            sum = sum ? *sum + w[i][e].value() : w[i][e].value();
+          }
         }
+        s.add(!a[i][j].value() || (sum.value() >= 1));
+      }
     }
 
     for (int32_t i = 0; i < num_vertices; i++) {
-        for (int32_t j = 0; j < num_vertices; j++) {
-            if (j < i) {
-                o_star[i][j] = !o_star[j][i].value();
-            }
+      absl::optional<z3::expr> sum;
+      for (int32_t e = 0; e < num_edges; e++) {
+        if (hypergraph.VerticesInEdge(edges_vec[e])
+                .value()
+                .contains(vertices_vec[i])) {
+          sum = sum ? *sum + w[i][e].value() : w[i][e].value();
         }
+      }
+      s.add(sum.value() >= 1);
     }
 
     for (int32_t i = 0; i < num_vertices; i++) {
-        for (int32_t j = 0; j < num_vertices; j++) {
-            for (int32_t k = 0; k < num_vertices; k++) {
-                if ((i == j) || (i == k) || (j == k)) { continue; }
-                s.add(!o_star[i][j].value()
-                      || !o_star[j][k].value()
-                      || o_star[i][k].value());
-            }
-        }
+      absl::optional<z3::expr> sum;
+      for (int32_t e = 0; e < num_edges; e++) {
+        sum = sum ? *sum + w[i][e].value() : w[i][e].value();
+      }
+      s.add(sum.value() <= m);
     }
+  }
 
-    for (auto edge : edges_vec) {
-        absl::flat_hash_set<V> vs = hypergraph.VerticesInEdge(edge).value();
-        for (const auto& x : vs) {
-            for (const auto& y : vs) {
-                auto i = vertex_to_int.at(x);
-                auto j = vertex_to_int.at(y);
+  z3::set_param("pp.decimal", true);
 
-                if (i >= j) { continue; }
-                s.add(o_star[j][i].value() || a[i][j].value());
-                s.add(o_star[i][j].value() || a[j][i].value());
-            }
-        }
+  s.minimize(m);
+
+  // std::cout << s.to_smt2() << "\n";
+
+  auto s_check = s.check();
+  if (s_check == z3::unsat) {
+    return absl::InternalError("Z3 returned unsat. This should never happen.");
+  } else if (s_check == z3::unknown) {
+    return absl::DeadlineExceededError("Z3 returned unknown. This usually "
+                                       "means it ran out of time or memory.");
+  }
+
+  auto model = s.get_model();
+  absl::optional<double> fhw;
+  LookupInModel(model, "m", [&fhw, &model](const z3::func_decl &decl) {
+    double temp;
+    if (model.get_const_interp(decl).is_numeral(temp)) {
+      fhw = temp;
     }
+  });
 
-    for (int32_t i = 0; i < num_vertices; i++) {
-        for (int32_t j = 0; j < num_vertices; j++) {
-            for (int32_t k = 0; k < num_vertices; k++) {
-                if ((i == j) || (i == k) || (j >= k)) { continue; }
-                s.add(!a[i][j].value()
-                      || !a[i][k].value()
-                      || o_star[k][j].value()
-                      || a[j][k].value());
-                s.add(!a[i][j].value()
-                      || !a[i][k].value()
-                      || o_star[j][k].value()
-                      || a[k][j].value());
-                s.add(!a[i][j].value()
-                      || !a[i][k].value()
-                      || a[j][k].value()
-                      || a[k][j].value());
-            }
-        }
+  std::vector<int32_t> ordering;
+  for (int32_t i = 0; i < num_vertices; i++) {
+    auto pos = ordering.begin();
+    for (int32_t j : ordering) {
+      bool ostar_j_i = false;
+      LookupInModel(model, absl::StrFormat("ostar_%d_%d", j, i),
+                    [&ostar_j_i, &model](const z3::func_decl &decl) {
+                      ostar_j_i = model.get_const_interp(decl).bool_value() ==
+                                  Z3_L_TRUE;
+                    });
+      if (!ostar_j_i) {
+        break;
+      }
+      pos++;
     }
+    ordering.insert(pos, i);
+  }
 
-    for (int32_t i = 0; i < num_vertices; i++) {
-        s.add(!a[i][i].value());
-    }
+  Digraph<Bag<V>> tree_graph;
 
-    {
-        for (int32_t i = 0; i < num_vertices; i++) {
-            for (int32_t j = 0; j < num_vertices; j++) {
-                if (i == j) { continue; }
-                absl::optional<z3::expr> sum;
-                for (int32_t e = 0; e < num_edges; e++) {
-                    if (hypergraph.VerticesInEdge(edges_vec[e]).value()
-                        .contains(vertices_vec[j])) {
-                        sum = sum
-                            ? *sum + w[i][e].value()
-                            : w[i][e].value();
-                    }
-                }
-                s.add(!a[i][j].value() || (sum.value() >= 1));
-            }
-        }
+  for (const V &vertex : vertices_vec) {
+    (void)tree_graph.AddVertex(Bag<V>());
+    // note: we are going to rely on the equivalence between indices in
+    // vertices_vec and valid NodeIds from here on.
+  }
 
-        for (int32_t i = 0; i < num_vertices; i++) {
-            absl::optional<z3::expr> sum;
-            for (int32_t e = 0; e < num_edges; e++) {
-                if (hypergraph.VerticesInEdge(edges_vec[e]).value()
-                    .contains(vertices_vec[i])) {
-                    sum = sum ? *sum + w[i][e].value() : w[i][e].value();
-                }
-            }
-            s.add(sum.value() >= 1);
-        }
-
-        for (int32_t i = 0; i < num_vertices; i++) {
-            absl::optional<z3::expr> sum;
-            for (int32_t e = 0; e < num_edges; e++) {
-                sum = sum ? *sum + w[i][e].value() : w[i][e].value();
-            }
-            s.add(sum.value() <= m);
-        }
-    }
-
-    z3::set_param("pp.decimal", true);
-
-    s.minimize(m);
-
-    // std::cout << s.to_smt2() << "\n";
-
-    auto s_check = s.check();
-    if (s_check == z3::unsat) {
-        return absl::InternalError("Z3 returned unsat. This should never happen.");
-    } else if (s_check == z3::unknown) {
-        return absl::DeadlineExceededError("Z3 returned unknown. This usually means it ran out of time or memory.");
-    }
-
-    auto model = s.get_model();
-    absl::optional<double> fhw;
-    LookupInModel(model, "m", [&fhw, &model](const z3::func_decl& decl) {
-        double temp;
-        if (model.get_const_interp(decl).is_numeral(temp)) {
-            fhw = temp;
-        }
-    });
-
-    std::vector<int32_t> ordering;
-    for (int32_t i = 0; i < num_vertices; i++) {
-        auto pos = ordering.begin();
-        for (int32_t j : ordering) {
-            bool ostar_j_i = false;
-            LookupInModel(model, absl::StrFormat("ostar_%d_%d", j, i),
-                          [&ostar_j_i, &model](const z3::func_decl& decl) {
-                              ostar_j_i =
-                                  model.get_const_interp(decl).bool_value()
-                                  == Z3_L_TRUE;
-                          });
-            if (!ostar_j_i) { break; }
-            pos++;
-        }
-        ordering.insert(pos, i);
-    }
-
-    Digraph<Bag<V>> tree_graph;
-
-    for (const V& vertex : vertices_vec) {
-        (void) tree_graph.AddVertex(Bag<V>());
-        // note: we are going to rely on the equivalence between indices in
-        // vertices_vec and valid NodeIds from here on.
-    }
-
-    for (int32_t i = 0; i < num_vertices; i++) {
-        for (int32_t e = 0; e < num_edges; e++) {
-            absl::optional<double> n;
-            LookupInModel(
-                model, absl::StrFormat("w_%d_%d", i, e),
-                [&n, &model](const z3::func_decl& decl) {
-                    double temp;
-                    if (model.get_const_interp(decl).is_numeral(temp)) {
+  for (int32_t i = 0; i < num_vertices; i++) {
+    for (int32_t e = 0; e < num_edges; e++) {
+      absl::optional<double> n;
+      LookupInModel(model, absl::StrFormat("w_%d_%d", i, e),
+                    [&n, &model](const z3::func_decl &decl) {
+                      double temp;
+                      if (model.get_const_interp(decl).is_numeral(temp)) {
                         n = temp;
-                    }
-                });
-            assert(n.has_value());
-            tree_graph.GetValue(i).relations[edges_vec[e]] = n.value();
-        }
+                      }
+                    });
+      assert(n.has_value());
+      tree_graph.GetValue(i).relations[edges_vec[e]] = n.value();
     }
+  }
 
-    auto smallest =
-        [&ordering, &vertices_vec](const absl::flat_hash_set<V>& x) -> absl::optional<int32_t> {
-            for (int32_t v : ordering) {
-                if (x.contains(vertices_vec[v])) {
-                    return v;
-                }
-            }
-            return absl::nullopt;
-        };
-
-    absl::flat_hash_map<V, absl::flat_hash_set<V>> chi;
-
-    for (HyperedgeId edge : edges_vec) {
-        auto vertices = hypergraph.VerticesInEdge(edge).value();
-        for (const V& vertex : vertices) {
-            tree_graph.GetValue(smallest(vertices).value()).attributes.insert(vertex);
-        }
-    }
-
+  auto smallest =
+      [&ordering, &vertices_vec](
+          const absl::flat_hash_set<V> &x) -> absl::optional<int32_t> {
     for (int32_t v : ordering) {
-        absl::flat_hash_set<V> temp = tree_graph.GetValue(v).attributes;
-        if (temp.size() > 1) {
-            temp.erase(vertices_vec[v]);
-            int32_t next = smallest(temp).value();
-            tree_graph.GetValue(next).attributes.merge(temp);
-            tree_graph.AddEdge(next, v);
-        }
+      if (x.contains(vertices_vec[v])) {
+        return v;
+      }
     }
+    return absl::nullopt;
+  };
 
-    auto tree = DigraphToTree(tree_graph).value();
+  absl::flat_hash_map<V, absl::flat_hash_set<V>> chi;
 
-/*    std::cerr << tree.Print([](const Bag<V>& bag) -> std::string {
-        std::vector<std::string> vec;
-
-        for (const auto& attribute : bag.attributes) {
-            vec.push_back(absl::StrFormat("\"%d\"", attribute));
-        }
-
-        return absl::StrCat(
-            "[",
-            absl::StrJoin(vec, ", "),
-            "]"
-        );
-    }) << "\n";
-
-    std::cerr << "Running Intersection Property: "
-              << VerifyRunningIntersectionProperty(tree_graph) << "\n";
-*/
-    if (!fhw.has_value()) {
-        return absl::InternalError("Could not find 'm' in the model.");
+  for (HyperedgeId edge : edges_vec) {
+    auto vertices = hypergraph.VerticesInEdge(edge).value();
+    for (const V &vertex : vertices) {
+      tree_graph.GetValue(smallest(vertices).value()).attributes.insert(vertex);
     }
-    if (!VerifyRunningIntersectionProperty(tree_graph)) {
-        return absl::InternalError("Result failed to satisfy running intersection property.");
-    }
+  }
 
-    return FHD<V> { fhw.value(), tree };
+  for (int32_t v : ordering) {
+    absl::flat_hash_set<V> temp = tree_graph.GetValue(v).attributes;
+    if (temp.size() > 1) {
+      temp.erase(vertices_vec[v]);
+      int32_t next = smallest(temp).value();
+      tree_graph.GetValue(next).attributes.merge(temp);
+      tree_graph.AddEdge(next, v);
+    }
+  }
+
+  auto tree = DigraphToTree(tree_graph).value();
+
+  /*    std::cerr << tree.Print([](const Bag<V>& bag) -> std::string {
+          std::vector<std::string> vec;
+
+          for (const auto& attribute : bag.attributes) {
+              vec.push_back(absl::StrFormat("\"%d\"", attribute));
+          }
+
+          return absl::StrCat(
+              "[",
+              absl::StrJoin(vec, ", "),
+              "]"
+          );
+      }) << "\n";
+
+      std::cerr << "Running Intersection Property: "
+                << VerifyRunningIntersectionProperty(tree_graph) << "\n";
+  */
+  if (!fhw.has_value()) {
+    return absl::InternalError("Could not find 'm' in the model.");
+  }
+  if (!VerifyRunningIntersectionProperty(tree_graph)) {
+    return absl::InternalError(
+        "Result failed to satisfy running intersection property.");
+  }
+
+  return FHD<V>{fhw.value(), tree};
 }
 
-template<typename S, typename T>
-std::pair<T, S> FlipPair(const std::pair<S, T>& pair) {
-    return {pair.second, pair.first};
+template <typename S, typename T>
+std::pair<T, S> FlipPair(const std::pair<S, T> &pair) {
+  return {pair.second, pair.first};
 }
 
-JoinOn FlipJoinOn(const JoinOn& join_on) {
-    JoinOn result;
-    for (const auto& pair : join_on) {
-        result.insert(FlipPair(pair));
-    }
-    return result;
+JoinOn FlipJoinOn(const JoinOn &join_on) {
+  JoinOn result;
+  for (const auto &pair : join_on) {
+    result.insert(FlipPair(pair));
+  }
+  return result;
 }
 
-Relation* Yannakakis(RelationFactory* factory,
-                     Tree<Relation*, JoinOn> join_tree) {
-    using TreeNode = Tree<Relation*, JoinOn>*;
-    absl::flat_hash_map<TreeNode, std::pair<TreeNode, JoinOn>> parent_of;
-    absl::flat_hash_set<TreeNode> leaf_nodes;
+Relation *Yannakakis(RelationFactory *factory,
+                     Tree<Relation *, JoinOn> join_tree) {
+  using TreeNode = Tree<Relation *, JoinOn> *;
+  absl::flat_hash_map<TreeNode, std::pair<TreeNode, JoinOn>> parent_of;
+  absl::flat_hash_set<TreeNode> leaf_nodes;
 
-    { // Compute `parent_of` and `leaf_nodes`
-        std::vector<TreeNode> active;
-        active.push_back(&join_tree);
-        while (!active.empty()) {
-            TreeNode node = active.back();
-            active.pop_back();
-            bool had_children = false;
-            for (auto& [subtree, join_on] : node->children) {
-                had_children = true;
-                TreeNode subnode = &subtree;
-                parent_of[subnode] = {node, join_on};
-                active.push_back(subnode);
-            }
-            if (!had_children) {
-                leaf_nodes.insert(node);
-            }
-        }
+  { // Compute `parent_of` and `leaf_nodes`
+    std::vector<TreeNode> active;
+    active.push_back(&join_tree);
+    while (!active.empty()) {
+      TreeNode node = active.back();
+      active.pop_back();
+      bool had_children = false;
+      for (auto &[subtree, join_on] : node->children) {
+        had_children = true;
+        TreeNode subnode = &subtree;
+        parent_of[subnode] = {node, join_on};
+        active.push_back(subnode);
+      }
+      if (!had_children) {
+        leaf_nodes.insert(node);
+      }
     }
+  }
 
-    { // First bottom-up pass
-        std::deque<TreeNode> active(leaf_nodes.begin(), leaf_nodes.end());
-        absl::flat_hash_set<TreeNode> inserted = leaf_nodes;
+  { // First bottom-up pass
+    std::deque<TreeNode> active(leaf_nodes.begin(), leaf_nodes.end());
+    absl::flat_hash_set<TreeNode> inserted = leaf_nodes;
 
-        while(!active.empty()) {
-            TreeNode node = active.back();
-            active.pop_back();
+    while (!active.empty()) {
+      TreeNode node = active.back();
+      active.pop_back();
 
-            if (parent_of.contains(node)) {
-                auto [parent, join_on] = parent_of.at(node);
+      if (parent_of.contains(node)) {
+        auto [parent, join_on] = parent_of.at(node);
 
-                parent->element =
-                    factory->Make<RelationSemijoin>(
-                        parent->element, node->element, join_on);
+        parent->element = factory->Make<RelationSemijoin>(
+            parent->element, node->element, join_on);
 
-                if (!inserted.contains(parent)) {
-                    active.push_front(parent);
-                    inserted.insert(parent);
-                }
-            }
+        if (!inserted.contains(parent)) {
+          active.push_front(parent);
+          inserted.insert(parent);
         }
+      }
     }
+  }
 
-    { // Top-down pass
-        std::deque<TreeNode> active;
-        active.push_front(&join_tree);
+  { // Top-down pass
+    std::deque<TreeNode> active;
+    active.push_front(&join_tree);
 
-        while(!active.empty()) {
-            TreeNode node = active.back();
-            active.pop_back();
+    while (!active.empty()) {
+      TreeNode node = active.back();
+      active.pop_back();
 
-            for (auto& [subtree, join_on] : node->children) {
-                TreeNode subnode = &subtree;
+      for (auto &[subtree, join_on] : node->children) {
+        TreeNode subnode = &subtree;
 
-                subnode->element =
-                    factory->Make<RelationSemijoin>(
-                        subnode->element, node->element, FlipJoinOn(join_on));
+        subnode->element = factory->Make<RelationSemijoin>(
+            subnode->element, node->element, FlipJoinOn(join_on));
 
-                active.push_front(subnode);
-            }
+        active.push_front(subnode);
+      }
+    }
+  }
+
+  { // Second bottom-up pass
+    std::deque<TreeNode> active(leaf_nodes.begin(), leaf_nodes.end());
+    absl::flat_hash_set<TreeNode> inserted = leaf_nodes;
+
+    while (!active.empty()) {
+      TreeNode node = active.back();
+      active.pop_back();
+
+      if (parent_of.contains(node)) {
+        auto [parent, join_on] = parent_of.at(node);
+
+        parent->element = factory->Make<RelationJoin>(parent->element,
+                                                      node->element, join_on);
+
+        if (!inserted.contains(parent)) {
+          active.push_front(parent);
+          inserted.insert(parent);
         }
+      }
     }
+  }
 
-    { // Second bottom-up pass
-        std::deque<TreeNode> active(leaf_nodes.begin(), leaf_nodes.end());
-        absl::flat_hash_set<TreeNode> inserted = leaf_nodes;
-
-        while(!active.empty()) {
-            TreeNode node = active.back();
-            active.pop_back();
-
-            if (parent_of.contains(node)) {
-                auto [parent, join_on] = parent_of.at(node);
-
-                parent->element =
-                    factory->Make<RelationJoin>(
-                        parent->element, node->element, join_on);
-
-                if (!inserted.contains(parent)) {
-                    active.push_front(parent);
-                    inserted.insert(parent);
-                }
-            }
-        }
-    }
-
-    return join_tree.element;
+  return join_tree.element;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_GHD_H_
+#endif // RDSS_GHD_H_

--- a/src/interpreter.hpp
+++ b/src/interpreter.hpp
@@ -43,240 +43,235 @@ using Tuple = std::vector<Value>;
 
 class Table {
 public:
-    Table(int32_t width_) : width(width_), values() {}
+  Table(int32_t width_) : width(width_), values() {}
 
-    Tuple GetTuple(int32_t index) const {
-        Tuple result;
-        for (int32_t i = 0; i < width; i++) {
-            result.push_back(values.at(index * width + i));
-        }
-        return result;
+  Tuple GetTuple(int32_t index) const {
+    Tuple result;
+    for (int32_t i = 0; i < width; i++) {
+      result.push_back(values.at(index * width + i));
     }
+    return result;
+  }
 
-    absl::Status InsertTuple(absl::Span<const Value> tuple) {
-        if (tuple.size() != width) {
-            return absl::InternalError(
-                "given tuple does not match table width");
-        }
-        for (const Value& val : tuple) {
-            values.push_back(val);
-        }
-        return absl::OkStatus();
+  absl::Status InsertTuple(absl::Span<const Value> tuple) {
+    if (tuple.size() != width) {
+      return absl::InternalError("given tuple does not match table width");
     }
+    for (const Value &val : tuple) {
+      values.push_back(val);
+    }
+    return absl::OkStatus();
+  }
 
-    int32_t NumberOfTuples() const {
-        RDSS_CHECK_EQ(values.size() % width, 0);
-        return values.size() / width;
-    }
+  int32_t NumberOfTuples() const {
+    RDSS_CHECK_EQ(values.size() % width, 0);
+    return values.size() / width;
+  }
 
-    int32_t Width() const {
-        return width;
-    }
+  int32_t Width() const { return width; }
 
 private:
-    int32_t width;
-    std::vector<Value> values;
+  int32_t width;
+  std::vector<Value> values;
 };
 
-bool InterpretPredicate(Predicate* predicate,
-                        const Tuple& tuple) {
-    if (auto p = DynamicCast<Predicate, PredicateAnd>(predicate)) {
-        bool result = true;
-        for (Predicate* child : p.value()->children) {
-            result &= InterpretPredicate(child, tuple);
-        }
-        return result;
-    } else if (auto p = DynamicCast<Predicate, PredicateOr>(predicate)) {
-        bool result = false;
-        for (Predicate* child : p.value()->children) {
-            result |= InterpretPredicate(child, tuple);
-        }
-        return result;
-    } else if (auto p = DynamicCast<Predicate, PredicateNot>(predicate)) {
-        return !InterpretPredicate(p.value()->pred, tuple);
-    } else if (auto p = DynamicCast<Predicate, PredicateLike>(predicate)) {
-        RDSS_CHECK(false) << "InterpretPredicate does not yet support LIKE";
-    } else if (auto p = DynamicCast<Predicate, PredicateLessThan>(predicate)) {
-        return tuple[p.value()->attr] < p.value()->integer;
-    } else if (auto p = DynamicCast<Predicate, PredicateEquals>(predicate)) {
-        return tuple[p.value()->attr] == p.value()->integer;
-    } else {
-        RDSS_CHECK(false)
-            << "If this is reached, a new predicate has been added but no "
-            << "case was added to the interpreter. Please add one.";
+bool InterpretPredicate(Predicate *predicate, const Tuple &tuple) {
+  if (auto p = DynamicCast<Predicate, PredicateAnd>(predicate)) {
+    bool result = true;
+    for (Predicate *child : p.value()->children) {
+      result &= InterpretPredicate(child, tuple);
     }
+    return result;
+  } else if (auto p = DynamicCast<Predicate, PredicateOr>(predicate)) {
+    bool result = false;
+    for (Predicate *child : p.value()->children) {
+      result |= InterpretPredicate(child, tuple);
+    }
+    return result;
+  } else if (auto p = DynamicCast<Predicate, PredicateNot>(predicate)) {
+    return !InterpretPredicate(p.value()->pred, tuple);
+  } else if (auto p = DynamicCast<Predicate, PredicateLike>(predicate)) {
+    RDSS_CHECK(false) << "InterpretPredicate does not yet support LIKE";
+  } else if (auto p = DynamicCast<Predicate, PredicateLessThan>(predicate)) {
+    return tuple[p.value()->attr] < p.value()->integer;
+  } else if (auto p = DynamicCast<Predicate, PredicateEquals>(predicate)) {
+    return tuple[p.value()->attr] == p.value()->integer;
+  } else {
+    RDSS_CHECK(false)
+        << "If this is reached, a new predicate has been added but no "
+        << "case was added to the interpreter. Please add one.";
+  }
 }
 
 class Interpreter {
 public:
-    Interpreter(const absl::btree_map<std::string, Table>& variables_)
-        : variables(variables_) {}
+  Interpreter(const absl::btree_map<std::string, Table> &variables_)
+      : variables(variables_) {}
 
-    absl::Status Interpret(Relation* input);
+  absl::Status Interpret(Relation *input);
 
-    absl::optional<Table> Lookup(Relation* input) {
-        if (context.contains(input)) {
-            return context.at(input);
-        }
-        return absl::nullopt;
+  absl::optional<Table> Lookup(Relation *input) {
+    if (context.contains(input)) {
+      return context.at(input);
     }
+    return absl::nullopt;
+  }
 
 private:
-    absl::btree_map<std::string, Table> variables;
-    absl::btree_map<Relation*, Table> context;
+  absl::btree_map<std::string, Table> variables;
+  absl::btree_map<Relation *, Table> context;
 };
 
-absl::Status Interpreter::Interpret(Relation* input) {
-    if (auto r = DynamicCast<Relation, RelationReference>(input)) {
-        context.insert_or_assign(input, variables.at(r.value()->name));
-    } else if (auto r = DynamicCast<Relation, RelationJoin>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->lhs));
-        RETURN_IF_ERROR(Interpret(r.value()->rhs));
+absl::Status Interpreter::Interpret(Relation *input) {
+  if (auto r = DynamicCast<Relation, RelationReference>(input)) {
+    context.insert_or_assign(input, variables.at(r.value()->name));
+  } else if (auto r = DynamicCast<Relation, RelationJoin>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->lhs));
+    RETURN_IF_ERROR(Interpret(r.value()->rhs));
 
-        auto lhs = &context.at(r.value()->lhs);
-        auto rhs = &context.at(r.value()->rhs);
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
-            for (int32_t j = 0; j < rhs->NumberOfTuples(); j++) {
-                auto lhs_tuple = lhs->GetTuple(i);
-                auto rhs_tuple = rhs->GetTuple(j);
-                bool add = true;
-                absl::flat_hash_set<Attr> rhs_nonincluded;
-                for (const auto& [x, y] : r.value()->attributes) {
-                    if (lhs_tuple[x] != rhs_tuple[y]) {
-                        add = false;
-                        break;
-                    }
-                    rhs_nonincluded.insert(y);
-                }
-                if (add) {
-                    Tuple result_tuple;
-                    for (Value value : lhs_tuple) {
-                        result_tuple.push_back(value);
-                    }
-                    for (int32_t k = 0; k < rhs->Width(); k++) {
-                        if (!rhs_nonincluded.contains(k)) {
-                            result_tuple.push_back(rhs_tuple[k]);
-                        }
-                    }
-                    RETURN_IF_ERROR(result.InsertTuple(result_tuple));
-                }
+    auto lhs = &context.at(r.value()->lhs);
+    auto rhs = &context.at(r.value()->rhs);
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
+      for (int32_t j = 0; j < rhs->NumberOfTuples(); j++) {
+        auto lhs_tuple = lhs->GetTuple(i);
+        auto rhs_tuple = rhs->GetTuple(j);
+        bool add = true;
+        absl::flat_hash_set<Attr> rhs_nonincluded;
+        for (const auto &[x, y] : r.value()->attributes) {
+          if (lhs_tuple[x] != rhs_tuple[y]) {
+            add = false;
+            break;
+          }
+          rhs_nonincluded.insert(y);
+        }
+        if (add) {
+          Tuple result_tuple;
+          for (Value value : lhs_tuple) {
+            result_tuple.push_back(value);
+          }
+          for (int32_t k = 0; k < rhs->Width(); k++) {
+            if (!rhs_nonincluded.contains(k)) {
+              result_tuple.push_back(rhs_tuple[k]);
             }
+          }
+          RETURN_IF_ERROR(result.InsertTuple(result_tuple));
         }
-        context.insert_or_assign(input, result);
-    } else if (auto r = DynamicCast<Relation, RelationSemijoin>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->lhs));
-        RETURN_IF_ERROR(Interpret(r.value()->rhs));
+      }
+    }
+    context.insert_or_assign(input, result);
+  } else if (auto r = DynamicCast<Relation, RelationSemijoin>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->lhs));
+    RETURN_IF_ERROR(Interpret(r.value()->rhs));
 
-        auto lhs = &context.at(r.value()->lhs);
-        auto rhs = &context.at(r.value()->rhs);
-        absl::flat_hash_set<Tuple> restricted_rhs;
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
-            auto tuple = rhs->GetTuple(i);
-            Tuple restricted_tuple;
-            for (const auto& [x, y] : r.value()->attributes) {
-                restricted_tuple.push_back(tuple[y]);
-            }
-            restricted_rhs.insert(restricted_tuple);
-        }
-        for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
-            auto tuple = lhs->GetTuple(i);
-            Tuple restricted_tuple;
-            for (const auto& [x, y] : r.value()->attributes) {
-                restricted_tuple.push_back(tuple[x]);
-            }
-            if (restricted_rhs.contains(restricted_tuple)) {
-                RETURN_IF_ERROR(result.InsertTuple(tuple));
-            }
-        }
-        context.insert_or_assign(input, result);
-    } else if (auto r = DynamicCast<Relation, RelationUnion>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->lhs));
-        RETURN_IF_ERROR(Interpret(r.value()->rhs));
+    auto lhs = &context.at(r.value()->lhs);
+    auto rhs = &context.at(r.value()->rhs);
+    absl::flat_hash_set<Tuple> restricted_rhs;
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
+      auto tuple = rhs->GetTuple(i);
+      Tuple restricted_tuple;
+      for (const auto &[x, y] : r.value()->attributes) {
+        restricted_tuple.push_back(tuple[y]);
+      }
+      restricted_rhs.insert(restricted_tuple);
+    }
+    for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
+      auto tuple = lhs->GetTuple(i);
+      Tuple restricted_tuple;
+      for (const auto &[x, y] : r.value()->attributes) {
+        restricted_tuple.push_back(tuple[x]);
+      }
+      if (restricted_rhs.contains(restricted_tuple)) {
+        RETURN_IF_ERROR(result.InsertTuple(tuple));
+      }
+    }
+    context.insert_or_assign(input, result);
+  } else if (auto r = DynamicCast<Relation, RelationUnion>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->lhs));
+    RETURN_IF_ERROR(Interpret(r.value()->rhs));
 
-        auto lhs = &context.at(r.value()->lhs);
-        auto rhs = &context.at(r.value()->rhs);
+    auto lhs = &context.at(r.value()->lhs);
+    auto rhs = &context.at(r.value()->rhs);
 
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
-            RETURN_IF_ERROR(result.InsertTuple(lhs->GetTuple(i)));
-        }
-        for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
-            RETURN_IF_ERROR(result.InsertTuple(rhs->GetTuple(i)));
-        }
-
-        context.insert_or_assign(input, result);
-    } else if (auto r = DynamicCast<Relation, RelationDifference>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->lhs));
-        RETURN_IF_ERROR(Interpret(r.value()->rhs));
-
-        auto lhs = &context.at(r.value()->lhs);
-        auto rhs = &context.at(r.value()->rhs);
-
-
-        absl::flat_hash_set<std::vector<Value>> tuples_in_rhs;
-        for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
-            tuples_in_rhs.insert(rhs->GetTuple(i));
-        }
-
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
-            auto tuple = lhs->GetTuple(i);
-            if (!tuples_in_rhs.contains(tuple)) {
-                RETURN_IF_ERROR(result.InsertTuple(tuple));
-            }
-        }
-
-        context.insert_or_assign(input, result);
-    } else if (auto r = DynamicCast<Relation, RelationSelect>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->rel));
-
-        auto predicate = r.value()->predicate;
-        auto rel = &context.at(r.value()->rel);
-
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < rel->NumberOfTuples(); i++) {
-            auto tuple = rel->GetTuple(i);
-            if (InterpretPredicate(predicate, tuple)) {
-                RETURN_IF_ERROR(result.InsertTuple(tuple));
-            }
-        }
-
-        context.insert_or_assign(input, result);
-    } else if (auto r = DynamicCast<Relation, RelationMap>(input)) {
-        return absl::InternalError("Interpreter cannot support Map");
-    } else if (auto r = DynamicCast<Relation, RelationView>(input)) {
-        RETURN_IF_ERROR(Interpret(r.value()->rel.rel));
-
-        auto perm = r.value()->rel.perm;
-        auto rel = &context.at(r.value()->rel.rel);
-
-        Table result(r.value()->Arity());
-        for (int32_t i = 0; i < rel->NumberOfTuples(); i++) {
-            Tuple input_tuple = rel->GetTuple(i);
-            Tuple output_tuple;
-            output_tuple.resize(result.Width(), Value());
-            int32_t j = 0;
-            for (absl::optional<Attr> attr_maybe : perm) {
-                if (attr_maybe) {
-                    output_tuple[*attr_maybe] = input_tuple[j];
-                }
-                j++;
-            }
-            RETURN_IF_ERROR(result.InsertTuple(output_tuple));
-        }
-
-        context.insert_or_assign(input, result);
-    } else {
-        return absl::InternalError(
-            "If this is reached, a new relation op has been added but no case "
-            "was added to the interpreter. Please add one.");
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
+      RETURN_IF_ERROR(result.InsertTuple(lhs->GetTuple(i)));
+    }
+    for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
+      RETURN_IF_ERROR(result.InsertTuple(rhs->GetTuple(i)));
     }
 
-    return absl::OkStatus();
+    context.insert_or_assign(input, result);
+  } else if (auto r = DynamicCast<Relation, RelationDifference>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->lhs));
+    RETURN_IF_ERROR(Interpret(r.value()->rhs));
+
+    auto lhs = &context.at(r.value()->lhs);
+    auto rhs = &context.at(r.value()->rhs);
+
+    absl::flat_hash_set<std::vector<Value>> tuples_in_rhs;
+    for (int32_t i = 0; i < rhs->NumberOfTuples(); i++) {
+      tuples_in_rhs.insert(rhs->GetTuple(i));
+    }
+
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < lhs->NumberOfTuples(); i++) {
+      auto tuple = lhs->GetTuple(i);
+      if (!tuples_in_rhs.contains(tuple)) {
+        RETURN_IF_ERROR(result.InsertTuple(tuple));
+      }
+    }
+
+    context.insert_or_assign(input, result);
+  } else if (auto r = DynamicCast<Relation, RelationSelect>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->rel));
+
+    auto predicate = r.value()->predicate;
+    auto rel = &context.at(r.value()->rel);
+
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < rel->NumberOfTuples(); i++) {
+      auto tuple = rel->GetTuple(i);
+      if (InterpretPredicate(predicate, tuple)) {
+        RETURN_IF_ERROR(result.InsertTuple(tuple));
+      }
+    }
+
+    context.insert_or_assign(input, result);
+  } else if (auto r = DynamicCast<Relation, RelationMap>(input)) {
+    return absl::InternalError("Interpreter cannot support Map");
+  } else if (auto r = DynamicCast<Relation, RelationView>(input)) {
+    RETURN_IF_ERROR(Interpret(r.value()->rel.rel));
+
+    auto perm = r.value()->rel.perm;
+    auto rel = &context.at(r.value()->rel.rel);
+
+    Table result(r.value()->Arity());
+    for (int32_t i = 0; i < rel->NumberOfTuples(); i++) {
+      Tuple input_tuple = rel->GetTuple(i);
+      Tuple output_tuple;
+      output_tuple.resize(result.Width(), Value());
+      int32_t j = 0;
+      for (absl::optional<Attr> attr_maybe : perm) {
+        if (attr_maybe) {
+          output_tuple[*attr_maybe] = input_tuple[j];
+        }
+        j++;
+      }
+      RETURN_IF_ERROR(result.InsertTuple(output_tuple));
+    }
+
+    context.insert_or_assign(input, result);
+  } else {
+    return absl::InternalError(
+        "If this is reached, a new relation op has been added but no case "
+        "was added to the interpreter. Please add one.");
+  }
+
+  return absl::OkStatus();
 }
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_INTERPRETER_H_
+#endif // RDSS_INTERPRETER_H_

--- a/src/logging/check_ops.hpp
+++ b/src/logging/check_ops.hpp
@@ -31,19 +31,19 @@
 // `NDEBUG` is defined, so `RDSS_DCHECK_EQ(x, y)` and so on do nothing. However,
 // we still want the compiler to parse `x` and `y`, because we don't want to
 // lose potentially useful errors and warnings.
-#define RDSS_LOGGING_INTERNAL_DCHECK_NOP(x, y) \
-  while (false && ((void)(x), (void)(y), 0))  \
+#define RDSS_LOGGING_INTERNAL_DCHECK_NOP(x, y)                                 \
+  while (false && ((void)(x), (void)(y), 0))                                   \
   ::rdss::logging_internal::NullStream().stream()
 #endif
 
-#define RDSS_LOGGING_INTERNAL_CHECK(failure_message) \
+#define RDSS_LOGGING_INTERNAL_CHECK(failure_message)                           \
   ::rdss::logging_internal::LogMessageFatal(__FILE__, __LINE__, failure_message)
-#define RDSS_LOGGING_INTERNAL_QCHECK(failure_message)                  \
-  ::rdss::logging_internal::LogMessageQuietlyFatal(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_QCHECK(failure_message)                          \
+  ::rdss::logging_internal::LogMessageQuietlyFatal(__FILE__, __LINE__,         \
                                                    failure_message)
 
 #define RDSS_LOGGING_INTERNAL_CHECK_OP(name, op, val1, val2)                   \
-  while (std::string* rdss_logging_internal_check_op_result                    \
+  while (std::string *rdss_logging_internal_check_op_result                    \
              ABSL_ATTRIBUTE_UNUSED = ::rdss::logging_internal::name##Impl(     \
                  ::rdss::logging_internal::GetReferenceableValue(val1),        \
                  ::rdss::logging_internal::GetReferenceableValue(val2),        \
@@ -51,7 +51,7 @@
                                                                   " " #val2))) \
   RDSS_LOGGING_INTERNAL_CHECK(*rdss_logging_internal_check_op_result).stream()
 #define RDSS_LOGGING_INTERNAL_QCHECK_OP(name, op, val1, val2)                  \
-  while (std::string* rdss_logging_internal_qcheck_op_result =                 \
+  while (std::string *rdss_logging_internal_qcheck_op_result =                 \
              ::rdss::logging_internal::name##Impl(                             \
                  ::rdss::logging_internal::GetReferenceableValue(val1),        \
                  ::rdss::logging_internal::GetReferenceableValue(val2),        \
@@ -89,20 +89,20 @@ namespace detect_specialization {
 // their 64-bit variant. This does not change the printed value, but reduces the
 // number of instantiations even further. Promoting an integer is very cheap at
 // the call site.
-int64_t operator<<(std::ostream&, short value);           // NOLINT
-int64_t operator<<(std::ostream&, unsigned short value);  // NOLINT
-int64_t operator<<(std::ostream&, int value);
-int64_t operator<<(std::ostream&, unsigned int value);
-int64_t operator<<(std::ostream&, long value);                 // NOLINT
-uint64_t operator<<(std::ostream&, unsigned long value);       // NOLINT
-int64_t operator<<(std::ostream&, long long value);            // NOLINT
-uint64_t operator<<(std::ostream&, unsigned long long value);  // NOLINT
-float operator<<(std::ostream&, float value);
-double operator<<(std::ostream&, double value);
-long double operator<<(std::ostream&, long double value);
-bool operator<<(std::ostream&, bool value);
-const void* operator<<(std::ostream&, const void* value);
-const void* operator<<(std::ostream&, std::nullptr_t);
+int64_t operator<<(std::ostream &, short value);          // NOLINT
+int64_t operator<<(std::ostream &, unsigned short value); // NOLINT
+int64_t operator<<(std::ostream &, int value);
+int64_t operator<<(std::ostream &, unsigned int value);
+int64_t operator<<(std::ostream &, long value);                // NOLINT
+uint64_t operator<<(std::ostream &, unsigned long value);      // NOLINT
+int64_t operator<<(std::ostream &, long long value);           // NOLINT
+uint64_t operator<<(std::ostream &, unsigned long long value); // NOLINT
+float operator<<(std::ostream &, float value);
+double operator<<(std::ostream &, double value);
+long double operator<<(std::ostream &, long double value);
+bool operator<<(std::ostream &, bool value);
+const void *operator<<(std::ostream &, const void *value);
+const void *operator<<(std::ostream &, std::nullptr_t);
 
 // These `char` overloads are specified like this in the standard, so we have to
 // write them exactly the same to ensure the call is ambiguous.
@@ -110,37 +110,37 @@ const void* operator<<(std::ostream&, std::nullptr_t);
 // template) then one call might have a higher rank than the other and it would
 // not be ambiguous.
 template <typename Traits>
-char operator<<(std::basic_ostream<char, Traits>&, char);
+char operator<<(std::basic_ostream<char, Traits> &, char);
 template <typename Traits>
-signed char operator<<(std::basic_ostream<char, Traits>&, signed char);
+signed char operator<<(std::basic_ostream<char, Traits> &, signed char);
 template <typename Traits>
-unsigned char operator<<(std::basic_ostream<char, Traits>&, unsigned char);
+unsigned char operator<<(std::basic_ostream<char, Traits> &, unsigned char);
 template <typename Traits>
-const char* operator<<(std::basic_ostream<char, Traits>&, const char*);
+const char *operator<<(std::basic_ostream<char, Traits> &, const char *);
 template <typename Traits>
-const signed char* operator<<(std::basic_ostream<char, Traits>&,
-                              const signed char*);
+const signed char *operator<<(std::basic_ostream<char, Traits> &,
+                              const signed char *);
 template <typename Traits>
-const unsigned char* operator<<(std::basic_ostream<char, Traits>&,
-                                const unsigned char*);
+const unsigned char *operator<<(std::basic_ostream<char, Traits> &,
+                                const unsigned char *);
 
 // This overload triggers when the call is not ambiguous.
 // It means that T is being printed with some overload not on this list.
 // We keep the value as `const T&`.
-template <typename T, typename = decltype(std::declval<std::ostream&>()
-                                          << std::declval<const T&>())>
-const T& Detect(int);
+template <typename T, typename = decltype(std::declval<std::ostream &>()
+                                          << std::declval<const T &>())>
+const T &Detect(int);
 
 // This overload triggers when the call is ambiguous.
 // It means that T is either one from this list or printed as one from this
 // list. Eg an enum that decays to `int` for printing.
 // We ask the overload set to give us the type we want to convert it to.
 template <typename T>
-decltype(detect_specialization::operator<<(std::declval<std::ostream&>(),
-                                           std::declval<const T&>()))
+decltype(detect_specialization::operator<<(std::declval<std::ostream &>(),
+                                           std::declval<const T &>()))
 Detect(char);
 
-}  // namespace detect_specialization
+} // namespace detect_specialization
 
 template <typename T>
 using CheckOpStreamType = decltype(detect_specialization::Detect<T>(0));
@@ -148,34 +148,34 @@ using CheckOpStreamType = decltype(detect_specialization::Detect<T>(0));
 // A helper class for formatting `expr (V1 vs. V2)` in a `CHECK_XX` statement.
 // See `MakeCheckOpString` for sample usage.
 class CheckOpMessageBuilder {
- public:
+public:
   // Inserts `exprtext` and ` (` to the stream.
-  explicit CheckOpMessageBuilder(const char* exprtext);
+  explicit CheckOpMessageBuilder(const char *exprtext);
   // For inserting the first variable.
-  std::ostream* ForVar1() { return stream_.get(); }
+  std::ostream *ForVar1() { return stream_.get(); }
   // For inserting the second variable (adds an intermediate ` vs. `).
-  std::ostream* ForVar2();
+  std::ostream *ForVar2();
   // Get the result (inserts the closing `)`).
-  std::string* NewString();
+  std::string *NewString();
 
- private:
+private:
   std::unique_ptr<std::ostringstream> stream_;
 };
 
 // This formats a value for a failing `CHECK_XX` statement. Ordinarily, it uses
 // the definition for `operator<<`, with a few special cases below.
 template <typename T>
-inline void MakeCheckOpValueString(std::ostream* os, const T& v) {
+inline void MakeCheckOpValueString(std::ostream *os, const T &v) {
   *os << NullGuard<T>::Guard(v);
 }
 
 // Build the error message string. Specify no inlining for code size.
 template <typename T1, typename T2>
-std::string* MakeCheckOpString(T1 v1, T2 v2,
-                               const char* exprtext) ABSL_ATTRIBUTE_NOINLINE;
+std::string *MakeCheckOpString(T1 v1, T2 v2,
+                               const char *exprtext) ABSL_ATTRIBUTE_NOINLINE;
 
 template <typename T1, typename T2>
-std::string* MakeCheckOpString(T1 v1, T2 v2, const char* exprtext) {
+std::string *MakeCheckOpString(T1 v1, T2 v2, const char *exprtext) {
   CheckOpMessageBuilder comb(exprtext);
   MakeCheckOpValueString(comb.ForVar1(), v1);
   MakeCheckOpValueString(comb.ForVar2(), v2);
@@ -186,17 +186,18 @@ std::string* MakeCheckOpString(T1 v1, T2 v2, const char* exprtext) {
 // `(int, int)` override works around the issue that the compiler will not
 // instantiate the template version of the function on values of unnamed enum
 // type.
-#define RDSS_LOGGING_INTERNAL_CHECK_OP_IMPL(name, op)                     \
-  template <typename T1, typename T2>                                     \
-  inline std::string* name##Impl(const T1& v1, const T2& v2,              \
-                                 const char* exprtext) {                  \
-    if (ABSL_PREDICT_TRUE(v1 op v2)) return nullptr;                      \
-    using U1 = CheckOpStreamType<T1>;                                     \
-    using U2 = CheckOpStreamType<T2>;                                     \
-    return MakeCheckOpString<U1, U2>(v1, v2, exprtext);                   \
-  }                                                                       \
-  inline std::string* name##Impl(int v1, int v2, const char* exprtext) {  \
-    return name##Impl<int, int>(v1, v2, exprtext);                        \
+#define RDSS_LOGGING_INTERNAL_CHECK_OP_IMPL(name, op)                          \
+  template <typename T1, typename T2>                                          \
+  inline std::string *name##Impl(const T1 &v1, const T2 &v2,                   \
+                                 const char *exprtext) {                       \
+    if (ABSL_PREDICT_TRUE(v1 op v2))                                           \
+      return nullptr;                                                          \
+    using U1 = CheckOpStreamType<T1>;                                          \
+    using U2 = CheckOpStreamType<T2>;                                          \
+    return MakeCheckOpString<U1, U2>(v1, v2, exprtext);                        \
+  }                                                                            \
+  inline std::string *name##Impl(int v1, int v2, const char *exprtext) {       \
+    return name##Impl<int, int>(v1, v2, exprtext);                             \
   }
 
 RDSS_LOGGING_INTERNAL_CHECK_OP_IMPL(Check_EQ, ==)
@@ -214,30 +215,29 @@ RDSS_LOGGING_INTERNAL_CHECK_OP_IMPL(Check_GT, >)
 //
 // This function avoids that problem for integers (the most common cases) by
 // overloading for every primitive integer type, and returning them by value.
-template <typename T>
-inline const T& GetReferenceableValue(const T& t) {
+template <typename T> inline const T &GetReferenceableValue(const T &t) {
   return t;
 }
 inline char GetReferenceableValue(char t) { return t; }
 inline unsigned char GetReferenceableValue(unsigned char t) { return t; }
 inline signed char GetReferenceableValue(signed char t) { return t; }
-inline short GetReferenceableValue(short t) { return t; }        // NOLINT
-inline unsigned short GetReferenceableValue(unsigned short t) {  // NOLINT
+inline short GetReferenceableValue(short t) { return t; }       // NOLINT
+inline unsigned short GetReferenceableValue(unsigned short t) { // NOLINT
   return t;
 }
 inline int GetReferenceableValue(int t) { return t; }
 inline unsigned int GetReferenceableValue(unsigned int t) { return t; }
-inline long GetReferenceableValue(long t) { return t; }        // NOLINT
-inline unsigned long GetReferenceableValue(unsigned long t) {  // NOLINT
+inline long GetReferenceableValue(long t) { return t; }       // NOLINT
+inline unsigned long GetReferenceableValue(unsigned long t) { // NOLINT
   return t;
 }
-inline long long GetReferenceableValue(long long t) { return t; }  // NOLINT
-inline unsigned long long GetReferenceableValue(                   // NOLINT
-    unsigned long long t) {                                        // NOLINT
+inline long long GetReferenceableValue(long long t) { return t; } // NOLINT
+inline unsigned long long GetReferenceableValue(                  // NOLINT
+    unsigned long long t) {                                       // NOLINT
   return t;
 }
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_CHECK_OPS_H_
+#endif // RDSS_LOGGING_CHECK_OPS_H_

--- a/src/logging/condition.hpp
+++ b/src/logging/condition.hpp
@@ -42,8 +42,8 @@
 // is equivalent to
 //
 //   RDSS_LOGGING_INTERNAL_CONDITION(x && y).
-#define RDSS_LOGGING_INTERNAL_CONDITION(condition) \
-  !(condition) ? (void)0 : ::rdss::logging_internal::LogMessageVoidify()&&
+#define RDSS_LOGGING_INTERNAL_CONDITION(condition)                             \
+  !(condition) ? (void)0 : ::rdss::logging_internal::LogMessageVoidify() &&
 
 namespace rdss {
 namespace logging_internal {
@@ -52,12 +52,12 @@ namespace logging_internal {
 // macros. This avoids compiler warnings like "value computed is not used" and
 // "statement has no effect".
 class LogMessageVoidify {
- public:
+public:
   // This has to be an operator with a precedence lower than << but higher than
   // ?:
-  void operator&&(const rdss::logging_internal::LogMessage&) {}
-  void operator&&(const std::ostream&) {}
-  void operator&&(const rdss::logging_internal::NullStream&) {}
+  void operator&&(const rdss::logging_internal::LogMessage &) {}
+  void operator&&(const std::ostream &) {}
+  void operator&&(const rdss::logging_internal::NullStream &) {}
 
   // This overload allows `RDSS_LOGGING_INTERNAL_CONDITION` to be used
   // consecutively.
@@ -77,7 +77,7 @@ class LogMessageVoidify {
   bool operator&&(bool b) { return b; }
 };
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_CONDITION_H_
+#endif // RDSS_LOGGING_CONDITION_H_

--- a/src/logging/errno_saver.hpp
+++ b/src/logging/errno_saver.hpp
@@ -25,16 +25,16 @@ namespace logging_internal {
 // upon deletion. It is used in low-level code and must be super fast. Do not
 // add instrumentation, even in debug modes.
 class ErrnoSaver {
- public:
+public:
   ErrnoSaver() : saved_errno_(errno) {}
   ~ErrnoSaver() { errno = saved_errno_; }
   int operator()() const { return saved_errno_; }
 
- private:
+private:
   const int saved_errno_;
 };
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_ERRNO_SAVER_H_
+#endif // RDSS_LOGGING_ERRNO_SAVER_H_

--- a/src/logging/log_entry.cpp
+++ b/src/logging/log_entry.cpp
@@ -40,7 +40,8 @@ absl::string_view Basename(absl::string_view filepath) {
 #else
   size_t path = filepath.find_last_of('/');
 #endif
-  if (path != filepath.npos) filepath.remove_prefix(path + 1);
+  if (path != filepath.npos)
+    filepath.remove_prefix(path + 1);
   return filepath;
 }
 
@@ -48,7 +49,7 @@ absl::string_view Basename(absl::string_view filepath) {
 constexpr size_t kFixedPrefixLen =
     sizeof("SMMDD HH:MM:SS.NNNNNN TTTTTTT ") - sizeof("");
 
-char* AppendTwoDigit(char* buf, uint32_t v) {
+char *AppendTwoDigit(char *buf, uint32_t v) {
   buf[1] = v % 10 + '0';
   buf[0] = v / 10 + '0';
   return buf + 2;
@@ -58,8 +59,8 @@ char* AppendTwoDigit(char* buf, uint32_t v) {
 // repetitions of "fill" if the representation is less than "width" characters
 // long.
 // REQUIRES: "out[]" must have sufficient space to hold the ascii string.
-char* AppendUint(char* out, uint32_t v, char fill, int width) {
-  char buf[32];  // Plenty to hold ascii representation of an int
+char *AppendUint(char *out, uint32_t v, char fill, int width) {
+  char buf[32]; // Plenty to hold ascii representation of an int
   int p = 32;
   do {
     buf[--p] = (v % 10) + '0';
@@ -75,19 +76,15 @@ char* AppendUint(char* out, uint32_t v, char fill, int width) {
   return out + n;
 }
 
-}  // namespace
+} // namespace
 
 LogEntry::LogEntry(absl::string_view full_filename, int line,
                    absl::LogSeverity severity, absl::Time timestamp)
-    : full_filename_(full_filename),
-      base_filename_(Basename(full_filename)),
-      line_(line),
-      prefix_(true),
+    : full_filename_(full_filename), base_filename_(Basename(full_filename)),
+      line_(line), prefix_(true),
       severity_(absl::NormalizeLogSeverity(severity)),
-      verbose_level_(kNoVerboseLevel),
-      timestamp_(timestamp),
-      tid_(GetCachedTID()),
-      text_message_("") {
+      verbose_level_(kNoVerboseLevel), timestamp_(timestamp),
+      tid_(GetCachedTID()), text_message_("") {
   GenerateTimestampAsTm();
 }
 
@@ -110,10 +107,10 @@ void LogEntry::GenerateTimestampAsTm() {
 #endif
 }
 
-void LogEntry::AppendSeverityTimeAndThreadId(std::string* out) const {
+void LogEntry::AppendSeverityTimeAndThreadId(std::string *out) const {
   // Append something like 'I0513 17:35:46.294773   27319 ' to *out
   char buf[kFixedPrefixLen];
-  char* p = buf;
+  char *p = buf;
   *p++ = absl::LogSeverityName(severity_)[0];
   p = AppendTwoDigit(p, timestamp_as_tm_.tm_mon + 1);
   p = AppendTwoDigit(p, timestamp_as_tm_.tm_mday);
@@ -149,7 +146,7 @@ std::string LogEntry::FormatPrefix() const {
   absl::StrAppend(&prefix, base_filename_);
   // Generate ':<line>] '
   char buf[kFixedPrefixLen];
-  char* p = buf;
+  char *p = buf;
   *p++ = ':';
   p = AppendUint(p, line_, ' ', 0);
   *p++ = ']';
@@ -171,4 +168,4 @@ std::string LogEntry::FormatPrefix() const {
   return prefix;
 }
 
-}  // namespace rdss
+} // namespace rdss

--- a/src/logging/log_entry.hpp
+++ b/src/logging/log_entry.hpp
@@ -29,7 +29,7 @@ class LogMessage;
 // Data returned by pointer or by reference must be copied if they are needed
 // after the lifetime of the `LogEntry`.
 class LogEntry {
- public:
+public:
   // For non-verbose log entries, `verbosity()` returns `kNoVerboseLevel`.
   static constexpr int kNoVerboseLevel = -1;
 
@@ -80,7 +80,7 @@ class LogEntry {
   // Breakdown of `timestamp()` in the local time zone.
   // Prefer using `timestamp()` unless you specifically need this breakdown
   // to do ASCII formatting, etc.
-  const struct tm& timestamp_as_tm() const { return timestamp_as_tm_; }
+  const struct tm &timestamp_as_tm() const { return timestamp_as_tm_; }
 
 #ifdef _WIN32
   uint32_t tid() const { return tid_; }
@@ -98,9 +98,9 @@ class LogEntry {
     text_message_ = text_message;
   }
 
- private:
+private:
   void GenerateTimestampAsTm();
-  void AppendSeverityTimeAndThreadId(std::string* out) const;
+  void AppendSeverityTimeAndThreadId(std::string *out) const;
   std::string FormatPrefix() const;
 
   absl::string_view full_filename_;
@@ -108,7 +108,7 @@ class LogEntry {
   int line_;
   bool prefix_;
   absl::LogSeverity severity_;
-  int verbose_level_;  // >=0 for `VLOG`, etc.; otherwise `kNoVerboseLevel`.
+  int verbose_level_; // >=0 for `VLOG`, etc.; otherwise `kNoVerboseLevel`.
   absl::Time timestamp_;
   struct tm timestamp_as_tm_;
 #ifdef _WIN32
@@ -121,6 +121,6 @@ class LogEntry {
   friend class ::rdss::logging_internal::LogMessage;
 };
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_LOG_ENTRY_H_
+#endif // RDSS_LOGGING_LOG_ENTRY_H_

--- a/src/logging/log_flags.cpp
+++ b/src/logging/log_flags.cpp
@@ -15,8 +15,7 @@
 
 #include "log_flags.hpp"
 
-ABSL_FLAG(int, minloglevel,
-          static_cast<int>(absl::LogSeverity::kInfo),
+ABSL_FLAG(int, minloglevel, static_cast<int>(absl::LogSeverity::kInfo),
           "Messages logged at a lower level than this don't actually "
           "get logged anywhere");
 

--- a/src/logging/log_flags.hpp
+++ b/src/logging/log_flags.hpp
@@ -21,4 +21,4 @@
 
 #include "log_flags.inc"
 
-#endif  // RDSS_LOGGING_LOG_FLAGS_H_
+#endif // RDSS_LOGGING_LOG_FLAGS_H_

--- a/src/logging/log_message.cpp
+++ b/src/logging/log_message.cpp
@@ -27,9 +27,9 @@
 #include <absl/time/time.h>
 #include <absl/types/span.h>
 
-#include "log_message.hpp"
 #include "log_entry.hpp"
 #include "log_flags.hpp"
+#include "log_message.hpp"
 #include "strerror.hpp"
 #include "symbolized_stacktrace.hpp"
 
@@ -39,21 +39,23 @@ namespace {
 
 // `global_sinks` holds globally registered `LogSink`s.
 ABSL_CONST_INIT absl::Mutex global_sinks_mutex(absl::kConstInit);
-ABSL_CONST_INIT std::vector<LogSink*>* global_sinks ABSL_GUARDED_BY(
-    global_sinks_mutex) ABSL_PT_GUARDED_BY(global_sinks_mutex) = nullptr;
+ABSL_CONST_INIT std::vector<LogSink *> *
+    global_sinks ABSL_GUARDED_BY(global_sinks_mutex)
+        ABSL_PT_GUARDED_BY(global_sinks_mutex) = nullptr;
 
 // `sink_send_mutex` protects against concurrent calls from the logging library
 // to any `LogSink::Send()`.
-ABSL_CONST_INIT absl::Mutex sink_send_mutex
-    ABSL_ACQUIRED_AFTER(global_sinks_mutex)(absl::kConstInit);
+ABSL_CONST_INIT absl::Mutex
+    sink_send_mutex ABSL_ACQUIRED_AFTER(global_sinks_mutex)(absl::kConstInit);
 
 // Have we already seen a fatal message?
 std::atomic_flag seen_fatal = ATOMIC_FLAG_INIT;
 
 // Copies into `dst` as many bytes of `src` as will fit, then truncates the
 // copied bytes from the front of `dst` and returns the number of bytes written.
-size_t AppendTruncated(absl::string_view src, absl::Span<char>* dst) {
-  if (src.size() > dst->size()) src = src.substr(0, dst->size());
+size_t AppendTruncated(absl::string_view src, absl::Span<char> *dst) {
+  if (src.size() > dst->size())
+    src = src.substr(0, dst->size());
   memcpy(dst->data(), src.data(), src.size());
   dst->remove_prefix(src.size());
   return src.size();
@@ -66,20 +68,20 @@ ABSL_CONST_INIT std::array<char, 512> fatal_message{{0}};
 
 // A write-only `std::streambuf` that writes into an `absl::Span<char>`.
 class SpanStreambuf : public std::streambuf {
- public:
+public:
   explicit SpanStreambuf(absl::Span<char> buf) {
     setp(buf.data(), buf.data() + buf.size());
   }
 
-  SpanStreambuf(SpanStreambuf&&) = default;
-  SpanStreambuf& operator=(SpanStreambuf&&) = default;
+  SpanStreambuf(SpanStreambuf &&) = default;
+  SpanStreambuf &operator=(SpanStreambuf &&) = default;
 
   absl::string_view data() const {
     return absl::string_view(pbase(), pptr() - pbase());
   }
 
- protected:
-  std::streamsize xsputn(const char* s, std::streamsize n) override {
+protected:
+  std::streamsize xsputn(const char *s, std::streamsize n) override {
     n = std::min<std::streamsize>(n, epptr() - pptr());
     memcpy(pptr(), s, n);
     pbump(n);
@@ -89,18 +91,18 @@ class SpanStreambuf : public std::streambuf {
 
 // Returns a mutable reference to a thread-local variable that should be true if
 // a `LogSink::Send()` is currently being invoked on this thread.
-inline bool& ThreadIsLogging() {
+inline bool &ThreadIsLogging() {
   static thread_local bool thread_is_logging = false;
   return thread_is_logging;
 }
 
-}  // namespace
+} // namespace
 
 struct LogMessage::LogMessageData {
-  LogMessageData(const char* file, int line, absl::LogSeverity severity,
+  LogMessageData(const char *file, int line, absl::LogSeverity severity,
                  absl::Time timestamp);
-  LogMessageData(const LogMessageData&) = delete;
-  LogMessageData& operator=(const LogMessageData&) = delete;
+  LogMessageData(const LogMessageData &) = delete;
+  LogMessageData &operator=(const LogMessageData &) = delete;
 
   // `LogEntry` sent to `LogSink`s; contains metadata.
   LogEntry entry;
@@ -115,7 +117,7 @@ struct LogMessage::LogMessageData {
   bool is_perror;
 
   // Extra `LogSink`s to log to, in addition to `global_sinks`.
-  absl::InlinedVector<LogSink*, 16> extra_sinks;
+  absl::InlinedVector<LogSink *, 16> extra_sinks;
   // If true, log to `extra_sinks` but not to `global_sinks` or hardcoded
   // non-sink targets (e.g. stderr, log files).
   bool extra_sinks_only;
@@ -137,14 +139,13 @@ struct LogMessage::LogMessageData {
   SpanStreambuf streambuf;
 };
 
-LogMessage::LogMessageData::LogMessageData(const char* file, int line,
+LogMessage::LogMessageData::LogMessageData(const char *file, int line,
                                            absl::LogSeverity severity,
                                            absl::Time timestamp)
-    : entry(file, line, severity, timestamp),
-      extra_sinks_only(false),
+    : entry(file, line, severity, timestamp), extra_sinks_only(false),
       streambuf(absl::MakeSpan(string_buf)) {}
 
-LogMessage::LogMessage(const char* file, int line, absl::LogSeverity severity)
+LogMessage::LogMessage(const char *file, int line, absl::LogSeverity severity)
     : data_(
           absl::make_unique<LogMessageData>(file, line, severity, absl::Now())),
       stream_(&data_->streambuf) {
@@ -173,29 +174,29 @@ LogMessage::LogMessage(const char* file, int line, absl::LogSeverity severity)
 
 LogMessage::~LogMessage() { Flush(); }
 
-LogMessage& LogMessage::WithCheckFailureMessage(absl::string_view msg) {
+LogMessage &LogMessage::WithCheckFailureMessage(absl::string_view msg) {
   stream() << "Check failed: " << msg << " ";
   return *this;
 }
 
-LogMessage& LogMessage::AtLocation(absl::string_view file, int line) {
+LogMessage &LogMessage::AtLocation(absl::string_view file, int line) {
   data_->entry.set_source_filename(file);
   data_->entry.set_source_line(line);
   LogBacktraceIfNeeded();
   return *this;
 }
 
-LogMessage& LogMessage::NoPrefix() {
+LogMessage &LogMessage::NoPrefix() {
   data_->entry.set_prefix(false);
   return *this;
 }
 
-LogMessage& LogMessage::WithPerror() {
+LogMessage &LogMessage::WithPerror() {
   data_->is_perror = true;
   return *this;
 }
 
-LogMessage& LogMessage::WithVerbosity(int verbose_level) {
+LogMessage &LogMessage::WithVerbosity(int verbose_level) {
   if (verbose_level == LogEntry::kNoVerboseLevel) {
     data_->entry.set_verbosity(LogEntry::kNoVerboseLevel);
   } else {
@@ -204,14 +205,14 @@ LogMessage& LogMessage::WithVerbosity(int verbose_level) {
   return *this;
 }
 
-LogMessage& LogMessage::ToSinkAlso(LogSink* sink) {
+LogMessage &LogMessage::ToSinkAlso(LogSink *sink) {
   if (sink != nullptr) {
     data_->extra_sinks.push_back(sink);
   }
   return *this;
 }
 
-LogMessage& LogMessage::ToSinkOnly(LogSink* sink) {
+LogMessage &LogMessage::ToSinkOnly(LogSink *sink) {
   data_->extra_sinks.clear();
   if (sink != nullptr) {
     data_->extra_sinks.push_back(sink);
@@ -254,30 +255,32 @@ void LogMessage::Flush() {
 void LogMessage::LogToSinks() const
     ABSL_LOCKS_EXCLUDED(global_sinks_mutex,
                         sink_send_mutex) ABSL_NO_THREAD_SAFETY_ANALYSIS {
-  if (!data_->extra_sinks_only) global_sinks_mutex.ReaderLock();
+  if (!data_->extra_sinks_only)
+    global_sinks_mutex.ReaderLock();
   if (!data_->extra_sinks.empty() ||
       (!data_->extra_sinks_only && global_sinks && !global_sinks->empty())) {
     {
       absl::MutexLock send_sink_lock(&sink_send_mutex);
-      for (LogSink* sink : data_->extra_sinks) {
+      for (LogSink *sink : data_->extra_sinks) {
         sink->Send(data_->entry);
       }
       if (!data_->extra_sinks_only && global_sinks) {
-        for (LogSink* sink : *global_sinks) {
+        for (LogSink *sink : *global_sinks) {
           sink->Send(data_->entry);
         }
       }
     }
-    for (LogSink* sink : data_->extra_sinks) {
+    for (LogSink *sink : data_->extra_sinks) {
       sink->WaitTillSent();
     }
     if (!data_->extra_sinks_only && global_sinks) {
-      for (LogSink* sink : *global_sinks) {
+      for (LogSink *sink : *global_sinks) {
         sink->WaitTillSent();
       }
     }
   }
-  if (!data_->extra_sinks_only) global_sinks_mutex.ReaderUnlock();
+  if (!data_->extra_sinks_only)
+    global_sinks_mutex.ReaderUnlock();
 }
 
 void LogMessage::Fail() {
@@ -338,15 +341,17 @@ size_t HashSiteForLogBacktraceAt(absl::string_view file, int line) {
   using HashTuple = std::tuple<absl::string_view, int>;
   return absl::Hash<HashTuple>()(HashTuple(file, line));
 }
-}  // namespace
+} // namespace
 
 void LogMessage::LogBacktraceIfNeeded() {
   const size_t flag_hash =
       log_backtrace_at_hash.load(std::memory_order_relaxed);
-  if (!flag_hash) return;
+  if (!flag_hash)
+    return;
   const size_t site_hash = HashSiteForLogBacktraceAt(
       data_->entry.source_basename(), data_->entry.source_line());
-  if (site_hash != flag_hash) return;
+  if (site_hash != flag_hash)
+    return;
   stream_ << " (stacktrace:\n";
   stream_ << GetSymbolizedStackTraceAsString(/*max_depth=*/50,
                                              /*skip_count=*/1);
@@ -413,7 +418,7 @@ void LogMessage::SendToLog() {
         data_->entry.source_basename(), ":", data_->entry.source_line(), " ",
         data_->streambuf.data(), "\n");
 
-      if (absl::GetFlag(FLAGS_logtostderr) ||
+    if (absl::GetFlag(FLAGS_logtostderr) ||
         absl::GetFlag(FLAGS_alsologtostderr) ||
         static_cast<int>(data_->entry.log_severity()) >=
             static_cast<int>(absl::GetFlag(FLAGS_stderrthreshold))) {
@@ -427,7 +432,7 @@ void LogMessage::SendToLog() {
       if (data_->entry.log_severity() >= absl::LogSeverity::kWarning) {
         fflush(stderr);
       }
-#endif  // _WIN32
+#endif // _WIN32
     }
   }
   PrepareToDieIfFatal();
@@ -436,29 +441,29 @@ void LogMessage::SendToLog() {
   DieIfFatal();
 }
 
-template LogMessage& LogMessage::operator<<(const char& v);
-template LogMessage& LogMessage::operator<<(const signed char& v);
-template LogMessage& LogMessage::operator<<(const unsigned char& v);
-template LogMessage& LogMessage::operator<<(const short& v);           // NOLINT
-template LogMessage& LogMessage::operator<<(const unsigned short& v);  // NOLINT
-template LogMessage& LogMessage::operator<<(const int& v);
-template LogMessage& LogMessage::operator<<(const unsigned int& v);
-template LogMessage& LogMessage::operator<<(const long& v);           // NOLINT
-template LogMessage& LogMessage::operator<<(const unsigned long& v);  // NOLINT
-template LogMessage& LogMessage::operator<<(const long long& v);      // NOLINT
-template LogMessage& LogMessage::operator<<(
-    const unsigned long long& v);  // NOLINT
-template LogMessage& LogMessage::operator<<(void* const& v);
-template LogMessage& LogMessage::operator<<(const void* const& v);
-template LogMessage& LogMessage::operator<<(const float& v);
-template LogMessage& LogMessage::operator<<(const double& v);
-template LogMessage& LogMessage::operator<<(const bool& v);
-template LogMessage& LogMessage::operator<<(const std::string& v);
-template LogMessage& LogMessage::operator<<(const absl::string_view& v);
-LogMessageFatal::LogMessageFatal(const char* file, int line)
+template LogMessage &LogMessage::operator<<(const char &v);
+template LogMessage &LogMessage::operator<<(const signed char &v);
+template LogMessage &LogMessage::operator<<(const unsigned char &v);
+template LogMessage &LogMessage::operator<<(const short &v);          // NOLINT
+template LogMessage &LogMessage::operator<<(const unsigned short &v); // NOLINT
+template LogMessage &LogMessage::operator<<(const int &v);
+template LogMessage &LogMessage::operator<<(const unsigned int &v);
+template LogMessage &LogMessage::operator<<(const long &v);          // NOLINT
+template LogMessage &LogMessage::operator<<(const unsigned long &v); // NOLINT
+template LogMessage &LogMessage::operator<<(const long long &v);     // NOLINT
+template LogMessage &
+LogMessage::operator<<(const unsigned long long &v); // NOLINT
+template LogMessage &LogMessage::operator<<(void *const &v);
+template LogMessage &LogMessage::operator<<(const void *const &v);
+template LogMessage &LogMessage::operator<<(const float &v);
+template LogMessage &LogMessage::operator<<(const double &v);
+template LogMessage &LogMessage::operator<<(const bool &v);
+template LogMessage &LogMessage::operator<<(const std::string &v);
+template LogMessage &LogMessage::operator<<(const absl::string_view &v);
+LogMessageFatal::LogMessageFatal(const char *file, int line)
     : LogMessage(file, line, absl::LogSeverity::kFatal) {}
 
-LogMessageFatal::LogMessageFatal(const char* file, int line,
+LogMessageFatal::LogMessageFatal(const char *file, int line,
                                  absl::string_view failure_msg)
     : LogMessage(file, line, absl::LogSeverity::kFatal) {
   WithCheckFailureMessage(failure_msg);
@@ -478,12 +483,12 @@ LogMessageFatal::~LogMessageFatal() {
 #pragma warning(pop)
 #endif
 
-LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char* file, int line)
+LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char *file, int line)
     : LogMessage(file, line, absl::LogSeverity::kFatal) {
   SetFailQuietly();
 }
 
-LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char* file, int line,
+LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char *file, int line,
                                                absl::string_view failure_msg)
     : LogMessage(file, line, absl::LogSeverity::kFatal) {
   SetFailQuietly();
@@ -495,20 +500,21 @@ LogMessageQuietlyFatal::~LogMessageQuietlyFatal() {
   LogMessage::FailQuietly();
 }
 
-}  // namespace logging_internal
+} // namespace logging_internal
 
-void AddLogSink(LogSink* sink)
+void AddLogSink(LogSink *sink)
     ABSL_LOCKS_EXCLUDED(logging_internal::global_sinks_mutex) {
   absl::MutexLock global_sinks_lock(&logging_internal::global_sinks_mutex);
   if (!logging_internal::global_sinks)
-    logging_internal::global_sinks = new std::vector<LogSink*>();
+    logging_internal::global_sinks = new std::vector<LogSink *>();
   logging_internal::global_sinks->push_back(sink);
 }
 
-void RemoveLogSink(LogSink* sink)
+void RemoveLogSink(LogSink *sink)
     ABSL_LOCKS_EXCLUDED(logging_internal::global_sinks_mutex) {
   absl::MutexLock global_sinks_lock(&logging_internal::global_sinks_mutex);
-  if (!logging_internal::global_sinks) return;
+  if (!logging_internal::global_sinks)
+    return;
   for (auto iter = logging_internal::global_sinks->begin();
        iter != logging_internal::global_sinks->end(); ++iter) {
     if (*iter == sink) {
@@ -518,4 +524,4 @@ void RemoveLogSink(LogSink* sink)
   }
 }
 
-}  // namespace rdss
+} // namespace rdss

--- a/src/logging/log_message.hpp
+++ b/src/logging/log_message.hpp
@@ -38,17 +38,17 @@ namespace logging_internal {
 // Heap-allocation of `LogMessage` is unsupported. Construction outside of a
 // `RDSS_LOG` macro is strongly discouraged.
 class LogMessage {
- public:
+public:
   // The size of the buffer in which structured log data is stored, and also of
   // the separate buffer in which text data is stored.
   static constexpr size_t BufferSize() { return 15000; }
 
   // Used for `RDSS_LOG`.
-  LogMessage(const char* file, int line,
+  LogMessage(const char *file, int line,
              absl::LogSeverity severity) ABSL_ATTRIBUTE_COLD;
 
-  LogMessage(const LogMessage&) = delete;
-  LogMessage& operator=(const LogMessage&) = delete;
+  LogMessage(const LogMessage &) = delete;
+  LogMessage &operator=(const LogMessage &) = delete;
 
   ~LogMessage() ABSL_ATTRIBUTE_COLD;
 
@@ -59,38 +59,38 @@ class LogMessage {
   // our streaming inside a chainable method call instead of explicitly in the
   // macro expansion. Streaming decays the type of the expression from
   // `LogMessage&` to `std::ostream&`.
-  LogMessage& WithCheckFailureMessage(absl::string_view msg);
+  LogMessage &WithCheckFailureMessage(absl::string_view msg);
 
   // Overrides the location inferred from the callsite. The string pointed to
   // by `file` must be valid until the end of the statement.
-  LogMessage& AtLocation(absl::string_view file, int line);
+  LogMessage &AtLocation(absl::string_view file, int line);
   // `loc` doesn't default to `SourceLocation::current()` here since the
   // callsite is already the default location for `LOG` statements.
-  LogMessage& AtLocation(xabsl::SourceLocation loc) {
+  LogMessage &AtLocation(xabsl::SourceLocation loc) {
     return AtLocation(loc.file_name(), loc.line());
   }
 
   // Omits the prefix from this line. The prefix includes metadata about the
   // logged data such as source code location and timestamp.
-  LogMessage& NoPrefix();
+  LogMessage &NoPrefix();
   // Appends to the logged message a colon, a space, a textual description of
   // the current value of `errno` (as by strerror(3)), and the numerical value
   // of `errno`.
-  LogMessage& WithPerror();
+  LogMessage &WithPerror();
   // Sets the verbosity field of the logged message as if it was logged by
   // `RDSS_VLOG(verbose_level)`. Unlike `RDSS_VLOG`, this method does not affect
   // evaluation of the statement when the specified `verbose_level` has been
   // disabled. The only effect is on `LogSink` implementations which make use
   // of the `LogSink::verbosity()` value. The value `LogEntry::kNoVerboseLevel`
   // can be specified to mark the message not verbose.
-  LogMessage& WithVerbosity(int verbose_level);
+  LogMessage &WithVerbosity(int verbose_level);
   // Sends this message to `*sink` in addition to whatever other sinks it would
   // otherwise have been sent to. `sink` must not be null.
-  LogMessage& ToSinkAlso(LogSink* sink);
+  LogMessage &ToSinkAlso(LogSink *sink);
   // Sends this message to `*sink` and no others. `sink` must not be null.
-  LogMessage& ToSinkOnly(LogSink* sink);
+  LogMessage &ToSinkOnly(LogSink *sink);
 
-  LogMessage& stream() { return *this; }
+  LogMessage &stream() { return *this; }
 
   // LogMessage accepts streamed values as if it were an ostream.
 
@@ -133,8 +133,8 @@ class LogMessage {
   // clang-format on
 
   // Handle stream manipulators e.g. std::endl.
-  LogMessage& operator<<(std::ostream& (*m)(std::ostream& os));
-  LogMessage& operator<<(std::ios_base& (*m)(std::ios_base& os));
+  LogMessage &operator<<(std::ostream &(*m)(std::ostream &os));
+  LogMessage &operator<<(std::ios_base &(*m)(std::ios_base &os));
 
   // Literal strings. This allows us to record C string literals as literals in
   // the logging.proto.Value.
@@ -147,16 +147,15 @@ class LogMessage {
   // `char[]` below should not be inlined. The compiler typically does not have
   // the string at compile time and cannot replace the call to `strlen` so
   // inlining it increases the binary size.
-  template <int SIZE>
-  LogMessage& operator<<(const char (&buf)[SIZE]);
+  template <int SIZE> LogMessage &operator<<(const char (&buf)[SIZE]);
 
   // This is prevents non-const `char[]` arrays from looking like literals.
   template <int SIZE>
-  LogMessage& operator<<(char (&buf)[SIZE]) ABSL_ATTRIBUTE_NOINLINE;
+  LogMessage &operator<<(char (&buf)[SIZE]) ABSL_ATTRIBUTE_NOINLINE;
 
   // Default: uses `ostream` logging to convert `v` to a string.
   template <typename T>
-  LogMessage& operator<<(const T& v) ABSL_ATTRIBUTE_NOINLINE;
+  LogMessage &operator<<(const T &v) ABSL_ATTRIBUTE_NOINLINE;
 
   // Note: We explicitly do not support `operator<<` for non-const references
   // because it breaks logging of non-integer bitfield types (i.e., enums).
@@ -169,7 +168,7 @@ class LogMessage {
   // The caller must ensure that this `LogMessage` pointer is not used past the
   // lifetime of the temporary object, e.g. by using it only in the wrapping
   // temporary object.
-  LogMessage* self() { return this; }
+  LogMessage *self() { return this; }
 
   // Call `abort()` or similar to perform `RDSS_LOG(FATAL)` crash.
   // Writes current stack trace to stderr.
@@ -179,24 +178,24 @@ class LogMessage {
   // that the caller has already generated and written the trace as appropriate.
   ABSL_ATTRIBUTE_NORETURN static void FailWithoutStackTrace();
 
- private:
-  struct LogMessageData;  // Opaque type containing message state
+private:
+  struct LogMessageData; // Opaque type containing message state
 
   void LogToSinks() const;
 
   void SendToLog();
 
- public:
+public:
   // Similar to `FailWithoutStackTrace()`, but without `abort()`. Terminates
   // the process with an error exit code.
   ABSL_ATTRIBUTE_NORETURN static void FailQuietly();
 
- protected:
+protected:
   // After this is called, failures are done as quiet as possible for this log
   // message.
   void SetFailQuietly();
 
- private:
+private:
   // Checks `FLAGS_log_backtrace_at` and appends a backtrace if appropriate.
   void LogBacktraceIfNeeded();
 
@@ -206,10 +205,10 @@ class LogMessage {
   // This one dies if the message is fatal.
   void DieIfFatal();
 
- protected:
+protected:
   void Flush();
 
- private:
+private:
   // This should be the first data member so that its initializer captures errno
   // before any other initializers alter it (e.g. with calls to new) and so that
   // no other destructors run afterward an alter it (e.g. with calls to delete).
@@ -223,29 +222,27 @@ class LogMessage {
 };
 
 // Note: the following is declared `ABSL_ATTRIBUTE_NOINLINE`
-template <typename T>
-LogMessage& LogMessage::operator<<(const T& v) {
+template <typename T> LogMessage &LogMessage::operator<<(const T &v) {
   stream_ << NullGuard<T>().Guard(v);
   return *this;
 }
-inline LogMessage& LogMessage::operator<<(
-    std::ostream& (*m)(std::ostream& os)) {
+inline LogMessage &
+LogMessage::operator<<(std::ostream &(*m)(std::ostream &os)) {
   stream_ << m;
   return *this;
 }
-inline LogMessage& LogMessage::operator<<(
-    std::ios_base& (*m)(std::ios_base& os)) {
+inline LogMessage &
+LogMessage::operator<<(std::ios_base &(*m)(std::ios_base &os)) {
   stream_ << m;
   return *this;
 }
 template <int SIZE>
-LogMessage& LogMessage::operator<<(const char (&buf)[SIZE]) {
+LogMessage &LogMessage::operator<<(const char (&buf)[SIZE]) {
   stream_ << buf;
   return *this;
 }
 // Note: the following is declared `ABSL_ATTRIBUTE_NOINLINE`
-template <int SIZE>
-LogMessage& LogMessage::operator<<(char (&buf)[SIZE]) {
+template <int SIZE> LogMessage &LogMessage::operator<<(char (&buf)[SIZE]) {
   stream_ << buf;
   return *this;
 }
@@ -253,48 +250,48 @@ LogMessage& LogMessage::operator<<(char (&buf)[SIZE]) {
 // We instantiate these specializations in the library's TU to save space in
 // other TUs. Since the template is marked `ABSL_ATTRIBUTE_NOINLINE` we will be
 // emitting a function call either way.
-extern template LogMessage& LogMessage::operator<<(const char& v);
-extern template LogMessage& LogMessage::operator<<(const signed char& v);
-extern template LogMessage& LogMessage::operator<<(const unsigned char& v);
-extern template LogMessage& LogMessage::operator<<(const short& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(
-    const unsigned short& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(const int& v);
-extern template LogMessage& LogMessage::operator<<(const unsigned int& v);
-extern template LogMessage& LogMessage::operator<<(const long& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(
-    const unsigned long& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(
-    const long long& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(
-    const unsigned long long& v);  // NOLINT
-extern template LogMessage& LogMessage::operator<<(void* const& v);
-extern template LogMessage& LogMessage::operator<<(const void* const& v);
-extern template LogMessage& LogMessage::operator<<(const float& v);
-extern template LogMessage& LogMessage::operator<<(const double& v);
-extern template LogMessage& LogMessage::operator<<(const bool& v);
-extern template LogMessage& LogMessage::operator<<(const std::string& v);
-extern template LogMessage& LogMessage::operator<<(const absl::string_view& v);
+extern template LogMessage &LogMessage::operator<<(const char &v);
+extern template LogMessage &LogMessage::operator<<(const signed char &v);
+extern template LogMessage &LogMessage::operator<<(const unsigned char &v);
+extern template LogMessage &LogMessage::operator<<(const short &v); // NOLINT
+extern template LogMessage &
+LogMessage::operator<<(const unsigned short &v); // NOLINT
+extern template LogMessage &LogMessage::operator<<(const int &v);
+extern template LogMessage &LogMessage::operator<<(const unsigned int &v);
+extern template LogMessage &LogMessage::operator<<(const long &v); // NOLINT
+extern template LogMessage &
+LogMessage::operator<<(const unsigned long &v); // NOLINT
+extern template LogMessage &
+LogMessage::operator<<(const long long &v); // NOLINT
+extern template LogMessage &
+LogMessage::operator<<(const unsigned long long &v); // NOLINT
+extern template LogMessage &LogMessage::operator<<(void *const &v);
+extern template LogMessage &LogMessage::operator<<(const void *const &v);
+extern template LogMessage &LogMessage::operator<<(const float &v);
+extern template LogMessage &LogMessage::operator<<(const double &v);
+extern template LogMessage &LogMessage::operator<<(const bool &v);
+extern template LogMessage &LogMessage::operator<<(const std::string &v);
+extern template LogMessage &LogMessage::operator<<(const absl::string_view &v);
 
 // `LogMessageFatal` ensures the process will exit in failure after logging this
 // message.
 class LogMessageFatal : public LogMessage {
- public:
-  LogMessageFatal(const char* file, int line) ABSL_ATTRIBUTE_COLD;
-  LogMessageFatal(const char* file, int line,
+public:
+  LogMessageFatal(const char *file, int line) ABSL_ATTRIBUTE_COLD;
+  LogMessageFatal(const char *file, int line,
                   absl::string_view failure_msg) ABSL_ATTRIBUTE_COLD;
   ABSL_ATTRIBUTE_NORETURN ~LogMessageFatal();
 };
 
 class LogMessageQuietlyFatal : public LogMessage {
- public:
-  LogMessageQuietlyFatal(const char* file, int line) ABSL_ATTRIBUTE_COLD;
-  LogMessageQuietlyFatal(const char* file, int line,
+public:
+  LogMessageQuietlyFatal(const char *file, int line) ABSL_ATTRIBUTE_COLD;
+  LogMessageQuietlyFatal(const char *file, int line,
                          absl::string_view failure_msg) ABSL_ATTRIBUTE_COLD;
   ABSL_ATTRIBUTE_NORETURN ~LogMessageQuietlyFatal();
 };
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_LOG_MESSAGE_H_
+#endif // RDSS_LOGGING_LOG_MESSAGE_H_

--- a/src/logging/log_sink.hpp
+++ b/src/logging/log_sink.hpp
@@ -24,7 +24,7 @@ namespace rdss {
 // must be thread-safe because a shared instance will be called from whichever
 // thread ran the `LOG()` line.
 class LogSink {
- public:
+public:
   virtual ~LogSink() = default;
 
   // `Send` is called synchronously during the log statement. The logging module
@@ -38,7 +38,7 @@ class LogSink {
   // `WaitTillSent` completes, so implementations may store a pointer to or
   // copy of `entry` (e.g. in a thread local variable) for use in
   // `WaitTillSent`.
-  virtual void Send(const LogEntry& entry) = 0;
+  virtual void Send(const LogEntry &entry) = 0;
 
   // `WaitTillSent` blocks the calling thread (the thread that generated a log
   // message) until the sink has finished processing the log message.
@@ -52,6 +52,6 @@ class LogSink {
   virtual void WaitTillSent() {}
 };
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_LOG_SINK_H_
+#endif // RDSS_LOGGING_LOG_SINK_H_

--- a/src/logging/logging.cpp
+++ b/src/logging/logging.cpp
@@ -25,22 +25,22 @@
 namespace rdss {
 namespace logging_internal {
 
-CheckOpMessageBuilder::CheckOpMessageBuilder(const char* exprtext)
+CheckOpMessageBuilder::CheckOpMessageBuilder(const char *exprtext)
     : stream_(new std::ostringstream) {
   *stream_ << exprtext << " (";
 }
 
-std::ostream* CheckOpMessageBuilder::ForVar2() {
+std::ostream *CheckOpMessageBuilder::ForVar2() {
   *stream_ << " vs. ";
   return stream_.get();
 }
 
-std::string* CheckOpMessageBuilder::NewString() {
+std::string *CheckOpMessageBuilder::NewString() {
   *stream_ << ")";
   return new std::string(stream_->str());
 }
 
-void MakeCheckOpValueString(std::ostream* os, const char v) {
+void MakeCheckOpValueString(std::ostream *os, const char v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
@@ -48,7 +48,7 @@ void MakeCheckOpValueString(std::ostream* os, const char v) {
   }
 }
 
-void MakeCheckOpValueString(std::ostream* os, const signed char v) {
+void MakeCheckOpValueString(std::ostream *os, const signed char v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
@@ -56,7 +56,7 @@ void MakeCheckOpValueString(std::ostream* os, const signed char v) {
   }
 }
 
-void MakeCheckOpValueString(std::ostream* os, const unsigned char v) {
+void MakeCheckOpValueString(std::ostream *os, const unsigned char v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
@@ -64,7 +64,7 @@ void MakeCheckOpValueString(std::ostream* os, const unsigned char v) {
   }
 }
 
-void MakeCheckOpValueString(std::ostream* os, const void* p) {
+void MakeCheckOpValueString(std::ostream *os, const void *p) {
   if (p == nullptr) {
     (*os) << "(null)";
   } else {
@@ -72,12 +72,12 @@ void MakeCheckOpValueString(std::ostream* os, const void* p) {
   }
 }
 
-void DieBecauseNull(const char* file, int line, const char* exprtext) {
+void DieBecauseNull(const char *file, int line, const char *exprtext) {
   RDSS_LOG(FATAL)
       .AtLocation(file, line)
       .WithCheckFailureMessage(
           absl::StrCat("'", exprtext, "' Must be non-null"));
 }
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss

--- a/src/logging/logging.hpp
+++ b/src/logging/logging.hpp
@@ -163,16 +163,16 @@
 // in comprise the logged message. Example:
 //
 //   RDSS_LOG(INFO) << "Found " << num_cookies << " cookies";
-#define RDSS_LOG(severity) \
-  switch (0)              \
-  default:                \
+#define RDSS_LOG(severity)                                                     \
+  switch (0)                                                                   \
+  default:                                                                     \
     RDSS_LOGGING_INTERNAL_LOG_##severity.stream()
 
-// `RDSS_VLOG` uses numeric levels to provide verbose logging that can configured
-// at runtime, including at a per-module level. `RDSS_VLOG` statements are
-// logged at `INFO` severity if they are logged at all; the numeric levels are
-// on a different scale than the proper severity levels. Positive levels are
-// disabled by default. Negative levels should not be used.
+// `RDSS_VLOG` uses numeric levels to provide verbose logging that can
+// configured at runtime, including at a per-module level. `RDSS_VLOG`
+// statements are logged at `INFO` severity if they are logged at all; the
+// numeric levels are on a different scale than the proper severity levels.
+// Positive levels are disabled by default. Negative levels should not be used.
 // Example:
 //
 //   RDSS_VLOG(1) << "I print when you run the program with --v=1 or higher";
@@ -186,16 +186,16 @@
 // If the condition is false, nothing is logged. Example:
 //
 //   RDSS_LOG_IF(INFO, num_cookies > 10) << "Got lots of cookies";
-#define RDSS_LOG_IF(severity, condition)       \
-  switch (0)                                   \
-  default:                                     \
-    RDSS_LOGGING_INTERNAL_CONDITION(condition) \
+#define RDSS_LOG_IF(severity, condition)                                       \
+  switch (0)                                                                   \
+  default:                                                                     \
+    RDSS_LOGGING_INTERNAL_CONDITION(condition)                                 \
   RDSS_LOGGING_INTERNAL_LOG_##severity.stream()
-#define RDSS_VLOG_IF(verbose_level, condition)                      \
-  switch (0)                                                        \
-  default:                                                          \
-    RDSS_LOGGING_INTERNAL_CONDITION((condition) &&                  \
-                                    RDSS_VLOG_IS_ON(verbose_level)) \
+#define RDSS_VLOG_IF(verbose_level, condition)                                 \
+  switch (0)                                                                   \
+  default:                                                                     \
+    RDSS_LOGGING_INTERNAL_CONDITION((condition) &&                             \
+                                    RDSS_VLOG_IS_ON(verbose_level))            \
   RDSS_LOGGING_INTERNAL_LOG_INFO.WithVerbosity(verbose_level).stream()
 
 // -----------------------------------------------------------------------------
@@ -219,20 +219,20 @@
 // Might produce a message like:
 //
 //   Check failed: !cheese.empty() Out of Cheese
-#define RDSS_CHECK(condition)                                         \
-  switch (0)                                                          \
-  default:                                                            \
-    RDSS_LOGGING_INTERNAL_CONDITION(ABSL_PREDICT_FALSE(!(condition))) \
+#define RDSS_CHECK(condition)                                                  \
+  switch (0)                                                                   \
+  default:                                                                     \
+    RDSS_LOGGING_INTERNAL_CONDITION(ABSL_PREDICT_FALSE(!(condition)))          \
   RDSS_LOGGING_INTERNAL_CHECK(#condition).stream()
 
 // `RDSS_QCHECK` behaves like `RDSS_CHECK` but does not print a full stack trace
 // and does not run registered error handlers (as `QFATAL`). It is useful when
 // the problem is definitely unrelated to program flow, e.g. when validating
 // user input.
-#define RDSS_QCHECK(condition)                                        \
-  switch (0)                                                          \
-  default:                                                            \
-    RDSS_LOGGING_INTERNAL_CONDITION(ABSL_PREDICT_FALSE(!(condition))) \
+#define RDSS_QCHECK(condition)                                                 \
+  switch (0)                                                                   \
+  default:                                                                     \
+    RDSS_LOGGING_INTERNAL_CONDITION(ABSL_PREDICT_FALSE(!(condition)))          \
   RDSS_LOGGING_INTERNAL_QCHECK(#condition).stream()
 
 // `RDSS_DCHECK` behaves like `RDSS_CHECK` in debug mode and does nothing
@@ -241,8 +241,8 @@
 #ifndef NDEBUG
 #define RDSS_DCHECK(condition) RDSS_CHECK(condition)
 #else
-#define RDSS_DCHECK(condition) \
-  while (false && (condition)) \
+#define RDSS_DCHECK(condition)                                                 \
+  while (false && (condition))                                                 \
   ::rdss::logging_internal::NullStreamFatal().stream()
 #endif
 
@@ -268,29 +268,29 @@
 //
 // WARNING: Passing `NULL` as an argument to `RDSS_CHECK_EQ` and similar macros
 // does not compile. Use `nullptr` instead.
-#define RDSS_CHECK_EQ(val1, val2) \
+#define RDSS_CHECK_EQ(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_EQ, ==, val1, val2)
-#define RDSS_CHECK_NE(val1, val2) \
+#define RDSS_CHECK_NE(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_NE, !=, val1, val2)
-#define RDSS_CHECK_LE(val1, val2) \
+#define RDSS_CHECK_LE(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_LE, <=, val1, val2)
-#define RDSS_CHECK_LT(val1, val2) \
+#define RDSS_CHECK_LT(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_LT, <, val1, val2)
-#define RDSS_CHECK_GE(val1, val2) \
+#define RDSS_CHECK_GE(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_GE, >=, val1, val2)
-#define RDSS_CHECK_GT(val1, val2) \
+#define RDSS_CHECK_GT(val1, val2)                                              \
   RDSS_LOGGING_INTERNAL_CHECK_OP(Check_GT, >, val1, val2)
-#define RDSS_QCHECK_EQ(val1, val2) \
+#define RDSS_QCHECK_EQ(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_EQ, ==, val1, val2)
-#define RDSS_QCHECK_NE(val1, val2) \
+#define RDSS_QCHECK_NE(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_NE, !=, val1, val2)
-#define RDSS_QCHECK_LE(val1, val2) \
+#define RDSS_QCHECK_LE(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_LE, <=, val1, val2)
-#define RDSS_QCHECK_LT(val1, val2) \
+#define RDSS_QCHECK_LT(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_LT, <, val1, val2)
-#define RDSS_QCHECK_GE(val1, val2) \
+#define RDSS_QCHECK_GE(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_GE, >=, val1, val2)
-#define RDSS_QCHECK_GT(val1, val2) \
+#define RDSS_QCHECK_GT(val1, val2)                                             \
   RDSS_LOGGING_INTERNAL_QCHECK_OP(Check_GT, >, val1, val2)
 
 #ifndef NDEBUG
@@ -329,15 +329,15 @@
 //
 // Use `RDSS_CHECK(ptr != nullptr)` if the returned pointer is
 // unused.
-#define RDSS_DIE_IF_NULL(val) \
+#define RDSS_DIE_IF_NULL(val)                                                  \
   ::rdss::logging_internal::DieIfNull(__FILE__, __LINE__, #val, (val))
 
 namespace rdss {
 
 // Add or remove a `LogSink` as a consumer of logging data. Thread-safe.
-void AddLogSink(LogSink* sink);
-void RemoveLogSink(LogSink* sink);
+void AddLogSink(LogSink *sink);
+void RemoveLogSink(LogSink *sink);
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_LOGGING_H_
+#endif // RDSS_LOGGING_LOGGING_H_

--- a/src/logging/logging_internal.hpp
+++ b/src/logging/logging_internal.hpp
@@ -34,30 +34,30 @@
 #define RDSS_LOGGING_INTERNAL_SEVERITY_FATAL ::absl::LogSeverity::kFatal
 #define RDSS_LOGGING_INTERNAL_SEVERITY_LEVEL(severity) (severity)
 
-#define RDSS_LOGGING_INTERNAL_LOG_INFO                     \
-  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_LOG_INFO                                         \
+  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__,                     \
                                        ::absl::LogSeverity::kInfo)
-#define RDSS_LOGGING_INTERNAL_LOG_WARNING                  \
-  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_LOG_WARNING                                      \
+  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__,                     \
                                        ::absl::LogSeverity::kWarning)
-#define RDSS_LOGGING_INTERNAL_LOG_ERROR                    \
-  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_LOG_ERROR                                        \
+  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__,                     \
                                        ::absl::LogSeverity::kError)
-#define RDSS_LOGGING_INTERNAL_LOG_FATAL \
+#define RDSS_LOGGING_INTERNAL_LOG_FATAL                                        \
   ::rdss::logging_internal::LogMessageFatal(__FILE__, __LINE__)
-#define RDSS_LOGGING_INTERNAL_LOG_QFATAL \
+#define RDSS_LOGGING_INTERNAL_LOG_QFATAL                                       \
   ::rdss::logging_internal::LogMessageQuietlyFatal(__FILE__, __LINE__)
 
 #ifdef NDEBUG
-#define RDSS_LOGGING_INTERNAL_LOG_DFATAL                   \
-  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_LOG_DFATAL                                       \
+  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__,                     \
                                        ::absl::LogSeverity::kError)
 #else
-#define RDSS_LOGGING_INTERNAL_LOG_DFATAL \
+#define RDSS_LOGGING_INTERNAL_LOG_DFATAL                                       \
   ::rdss::logging_internal::LogMessageFatal(__FILE__, __LINE__)
 #endif
-#define RDSS_LOGGING_INTERNAL_LOG_LEVEL(severity)          \
-  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__, \
+#define RDSS_LOGGING_INTERNAL_LOG_LEVEL(severity)                              \
+  ::rdss::logging_internal::LogMessage(__FILE__, __LINE__,                     \
                                        ::absl::NormalizeLogSeverity(severity))
 
 namespace rdss {
@@ -67,8 +67,8 @@ namespace logging_internal {
 // `line` location. Called when `RDSS_DIE_IF_NULL` fails. Calling this function
 // generates less code than its implementation would if inlined, for a slight
 // code size reduction each time `RDSS_DIE_IF_NULL` is called.
-ABSL_ATTRIBUTE_NORETURN ABSL_ATTRIBUTE_NOINLINE void DieBecauseNull(
-    const char* file, int line, const char* exprtext);
+ABSL_ATTRIBUTE_NORETURN ABSL_ATTRIBUTE_NOINLINE void
+DieBecauseNull(const char *file, int line, const char *exprtext);
 
 // Helper for `RDSS_DIE_IF_NULL`.
 //
@@ -78,8 +78,8 @@ ABSL_ATTRIBUTE_NORETURN ABSL_ATTRIBUTE_NOINLINE void DieBecauseNull(
 //
 //   Foo() : bar_(RDSS_DIE_IF_NULL(MethodReturningUniquePtr())) {}
 template <typename T>
-ABSL_MUST_USE_RESULT T DieIfNull(const char* file, int line,
-                                 const char* exprtext, T&& t) {
+ABSL_MUST_USE_RESULT T DieIfNull(const char *file, int line,
+                                 const char *exprtext, T &&t) {
   if (ABSL_PREDICT_FALSE(t == nullptr)) {
     // Call a non-inline helper function for a small code size improvement.
     DieBecauseNull(file, line, exprtext);
@@ -87,7 +87,7 @@ ABSL_MUST_USE_RESULT T DieIfNull(const char* file, int line,
   return std::forward<T>(t);
 }
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_LOGGING_INTERNAL_H_
+#endif // RDSS_LOGGING_LOGGING_INTERNAL_H_

--- a/src/logging/null_guard.hpp
+++ b/src/logging/null_guard.hpp
@@ -25,24 +25,20 @@ namespace logging_internal {
 // nullptr_t, or a null char* or const char*, in which case it returns "(null)".
 // This allows streaming NullGuard<T>::Guard(v) to an output stream without
 // hitting undefined behavior for null values.
-template <typename T>
-struct NullGuard {
-  static const T& Guard(const T& v) { return v; }
+template <typename T> struct NullGuard {
+  static const T &Guard(const T &v) { return v; }
 };
-template <>
-struct NullGuard<char*> {
-  static const char* Guard(const char* v) { return v ? v : "(null)"; }
+template <> struct NullGuard<char *> {
+  static const char *Guard(const char *v) { return v ? v : "(null)"; }
 };
-template <>
-struct NullGuard<const char*> {
-  static const char* Guard(const char* v) { return v ? v : "(null)"; }
+template <> struct NullGuard<const char *> {
+  static const char *Guard(const char *v) { return v ? v : "(null)"; }
 };
-template <>
-struct NullGuard<std::nullptr_t> {
-  static const char* Guard(const std::nullptr_t&) { return "(null)"; }
+template <> struct NullGuard<std::nullptr_t> {
+  static const char *Guard(const std::nullptr_t &) { return "(null)"; }
 };
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_NULL_GUARD_H_
+#endif // RDSS_LOGGING_NULL_GUARD_H_

--- a/src/logging/null_stream.hpp
+++ b/src/logging/null_stream.hpp
@@ -31,27 +31,27 @@ namespace logging_internal {
 // compiler can eliminate the whole instance and discard anything that's
 // streamed in.
 class NullStream {
- public:
-  NullStream& stream() { return *this; }
-  NullStream& WithCheckFailureMessage(absl::string_view) { return *this; }
-  NullStream& AtLocation(absl::string_view, int) { return *this; }
-  NullStream& AtLocation(xabsl::SourceLocation) { return *this; }
-  NullStream& NoPrefix() { return *this; }
-  NullStream& WithPerror() { return *this; }
-  NullStream& WithVerbosity(int) { return *this; }
-  NullStream& ToSinkAlso(LogSink*) { return *this; }
-  NullStream& ToSinkOnly(LogSink*) { return *this; }
+public:
+  NullStream &stream() { return *this; }
+  NullStream &WithCheckFailureMessage(absl::string_view) { return *this; }
+  NullStream &AtLocation(absl::string_view, int) { return *this; }
+  NullStream &AtLocation(xabsl::SourceLocation) { return *this; }
+  NullStream &NoPrefix() { return *this; }
+  NullStream &WithPerror() { return *this; }
+  NullStream &WithVerbosity(int) { return *this; }
+  NullStream &ToSinkAlso(LogSink *) { return *this; }
+  NullStream &ToSinkOnly(LogSink *) { return *this; }
 };
 template <typename T>
-inline NullStream& operator<<(NullStream& str, const T&) {
+inline NullStream &operator<<(NullStream &str, const T &) {
   return str;
 }
-inline NullStream& operator<<(NullStream& str,
-                              std::ostream& (*)(std::ostream& os)) {
+inline NullStream &operator<<(NullStream &str,
+                              std::ostream &(*)(std::ostream &os)) {
   return str;
 }
-inline NullStream& operator<<(NullStream& str,
-                              std::ios_base& (*)(std::ios_base& os)) {
+inline NullStream &operator<<(NullStream &str,
+                              std::ios_base &(*)(std::ios_base &os)) {
   return str;
 }
 
@@ -59,12 +59,12 @@ inline NullStream& operator<<(NullStream& str,
 // `LogMessageFatal`, which means it always terminates the process.
 // `DFATAL` and expression-defined severity use `NullStreamMaybeFatal` above.
 class NullStreamFatal : public NullStream {
- public:
+public:
   NullStreamFatal() {}
   ABSL_ATTRIBUTE_NORETURN ~NullStreamFatal() { _exit(1); }
 };
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_NULL_STREAM_H_
+#endif // RDSS_LOGGING_NULL_STREAM_H_

--- a/src/logging/source_location.hpp
+++ b/src/logging/source_location.hpp
@@ -46,21 +46,19 @@ namespace xabsl {
 // `xabsl::SourceLocation` is copyable.
 class SourceLocation {
   struct PrivateTag {
-   private:
+  private:
     explicit PrivateTag() = default;
     friend class SourceLocation;
   };
 
- public:
+public:
   // Avoid this constructor; it populates the object with dummy values.
-  constexpr SourceLocation()
-      : line_(0),
-        file_name_(nullptr) {}
+  constexpr SourceLocation() : line_(0), file_name_(nullptr) {}
 
   // Wrapper to invoke the private constructor below. This should only be used
   // by the `XABSL_LOC` macro, hence the name.
   static constexpr SourceLocation DoNotInvokeDirectly(std::uint_least32_t line,
-                                                       const char* file_name) {
+                                                      const char *file_name) {
     return SourceLocation(line, file_name);
   }
 
@@ -82,9 +80,10 @@ class SourceLocation {
   //     TracedAdd(1);
   //     TracedAdd(2);
   //   }
-  static constexpr SourceLocation current(
-      PrivateTag = PrivateTag{}, std::uint_least32_t line = __builtin_LINE(),
-      const char* file_name = __builtin_FILE()) {
+  static constexpr SourceLocation
+  current(PrivateTag = PrivateTag{},
+          std::uint_least32_t line = __builtin_LINE(),
+          const char *file_name = __builtin_FILE()) {
     return SourceLocation(line, file_name);
   }
 #else
@@ -98,20 +97,19 @@ class SourceLocation {
   constexpr std::uint_least32_t line() const { return line_; }
 
   // The file name of the captured source location.
-  constexpr const char* file_name() const { return file_name_; }
+  constexpr const char *file_name() const { return file_name_; }
 
   // `column()` and `function_name()` are omitted because we don't have a way to
   // support them.
 
- private:
+private:
   // Do not invoke this constructor directly. Instead, use the `XABSL_LOC` macro
   // below.
   //
   // `file_name` must outlive all copies of the `xabsl::SourceLocation` object,
   // so in practice it should be a string literal.
-  constexpr SourceLocation(std::uint_least32_t line, const char* file_name)
-      : line_(line),
-        file_name_(file_name) {}
+  constexpr SourceLocation(std::uint_least32_t line, const char *file_name)
+      : line_(line), file_name_(file_name) {}
 
   friend constexpr int UseUnused() {
     static_assert(SourceLocation(0, nullptr).unused_column_ == 0,
@@ -123,14 +121,14 @@ class SourceLocation {
   // type.
   std::uint_least32_t line_;
   std::uint_least32_t unused_column_ = 0;
-  const char* file_name_;
+  const char *file_name_;
 };
 
-}  // namespace xabsl
+} // namespace xabsl
 
 // If a function takes an `xabsl::SourceLocation` parameter, pass this as the
 // argument.
-#define XABSL_LOC \
+#define XABSL_LOC                                                              \
   ::xabsl::SourceLocation::DoNotInvokeDirectly(__LINE__, __FILE__)
 
 // ABSL_LOC_CURRENT_DEFAULT_ARG
@@ -152,4 +150,4 @@ class SourceLocation {
 #define XABSL_LOC_CURRENT_DEFAULT_ARG
 #endif
 
-#endif  // RDSS_LOGGING_SOURCE_LOCATION_H_
+#endif // RDSS_LOGGING_SOURCE_LOCATION_H_

--- a/src/logging/strerror.cpp
+++ b/src/logging/strerror.cpp
@@ -29,7 +29,7 @@ std::string Strerror(int error_num) {
   // int where 0 indicates success.
   using strerror_r_type = decltype(strerror_r(0, nullptr, 0));
   constexpr bool kXsiCompliant = std::is_same<strerror_r_type, int>::value;
-  constexpr bool kGnuSpecific = std::is_same<strerror_r_type, char*>::value;
+  constexpr bool kGnuSpecific = std::is_same<strerror_r_type, char *>::value;
   static_assert(kXsiCompliant != kGnuSpecific,
                 "strerror_r should be either the XSI-compliant version or the "
                 "GNU-specific version");
@@ -46,8 +46,8 @@ std::string Strerror(int error_num) {
   } else if constexpr (kGnuSpecific) {
     // Note that without the `reinterpret_cast`, this cannot be compiled with
     // the XSI-compliant version of strerror_r.
-    return reinterpret_cast<char*>(strerror_r(error_num, buffer, kBufferSize));
+    return reinterpret_cast<char *>(strerror_r(error_num, buffer, kBufferSize));
   }
 }
 
-}  // namespace rdss
+} // namespace rdss

--- a/src/logging/strerror.hpp
+++ b/src/logging/strerror.hpp
@@ -23,6 +23,6 @@ namespace rdss {
 // Thread safe version of strerror.
 std::string Strerror(int error_num);
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_STRERROR_H_
+#endif // RDSS_LOGGING_STRERROR_H_

--- a/src/logging/symbolized_stacktrace.cpp
+++ b/src/logging/symbolized_stacktrace.cpp
@@ -28,12 +28,12 @@ std::string GetSymbolizedStackTraceAsString(int max_depth, int skip_count,
                                             bool demangle) {
   std::string result;
   int skip_count_including_self = skip_count + 1;
-  std::vector<void*> stack_trace;
+  std::vector<void *> stack_trace;
   stack_trace.resize(max_depth);
   stack_trace.resize(absl::GetStackTrace(stack_trace.data(), max_depth,
                                          skip_count_including_self));
   std::array<char, 256> symbol_name_buffer;
-  for (void* pc : stack_trace) {
+  for (void *pc : stack_trace) {
     if (absl::Symbolize(pc, symbol_name_buffer.data(),
                         symbol_name_buffer.size())) {
       result += absl::StrFormat("%08p: %s\n", pc, symbol_name_buffer.data());
@@ -44,4 +44,4 @@ std::string GetSymbolizedStackTraceAsString(int max_depth, int skip_count,
   return result;
 }
 
-}  // namespace rdss
+} // namespace rdss

--- a/src/logging/symbolized_stacktrace.hpp
+++ b/src/logging/symbolized_stacktrace.hpp
@@ -32,6 +32,6 @@ std::string GetSymbolizedStackTraceAsString(int max_depth = 50,
                                             int skip_count = 0,
                                             bool demangle = true);
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_LOGGING_SYMBOLIZED_STACKTRACE_H_
+#endif // RDSS_LOGGING_SYMBOLIZED_STACKTRACE_H_

--- a/src/logging/vlog_is_on.cpp
+++ b/src/logging/vlog_is_on.cpp
@@ -17,8 +17,8 @@
 #include <absl/strings/str_split.h>
 #include <absl/strings/strip.h>
 
-#include "vlog_is_on.hpp"
 #include "errno_saver.hpp"
+#include "vlog_is_on.hpp"
 #include "vlog_is_on.inc"
 
 // Construct a logging site from a logging level and epoch.
@@ -49,9 +49,11 @@ bool SafeFNMatch(absl::string_view pattern, absl::string_view str) {
     }
     if (pattern.front() == '*') {
       pattern.remove_prefix(1);
-      if (pattern.empty()) return true;
+      if (pattern.empty())
+        return true;
       do {
-        if (SafeFNMatch(pattern, str)) return true;
+        if (SafeFNMatch(pattern, str))
+          return true;
         str.remove_prefix(1);
       } while (!str.empty());
       return false;
@@ -64,7 +66,7 @@ bool SafeFNMatch(absl::string_view pattern, absl::string_view str) {
     return false;
   }
 }
-}  // namespace logging_internal
+} // namespace logging_internal
 
 // List of per-module log levels from FLAGS_vmodule. Once created
 // each element is never deleted/modified except for the vlog_level:
@@ -73,15 +75,15 @@ bool SafeFNMatch(absl::string_view pattern, absl::string_view str) {
 // delete/update it: other threads need to use it w/o locks.
 struct VModuleInfo {
   std::string module_pattern;
-  bool module_is_path;  // i.e. it contains a path separator
+  bool module_is_path; // i.e. it contains a path separator
   mutable std::atomic<int> vlog_level;
-  const VModuleInfo* next;
+  const VModuleInfo *next;
 };
 
 // Pointer to head of the VModuleInfo list.
 // It's a map from module pattern to logging level for those module(s).
 // Protected by vmodule_loc in the associated .inc file.
-static std::atomic<VModuleInfo*> vmodule_list;
+static std::atomic<VModuleInfo *> vmodule_list;
 
 // Logging sites initialize their epochs to zero. We initialize the
 // global epoch to 1, so that all logging sites are initially stale.
@@ -92,8 +94,8 @@ int SetVLOGLevel(absl::string_view module_pattern, int log_level) {
   int result = absl::GetFlag(FLAGS_v);
   bool found = false;
   absl::base_internal::SpinLockHolder l(
-      &logging_internal::vmodule_lock);  // protect whole read-modify-write
-  for (const VModuleInfo* info = vmodule_list.load(std::memory_order_relaxed);
+      &logging_internal::vmodule_lock); // protect whole read-modify-write
+  for (const VModuleInfo *info = vmodule_list.load(std::memory_order_relaxed);
        info != nullptr; info = info->next) {
     if (info->module_pattern == module_pattern) {
       if (!found) {
@@ -108,7 +110,7 @@ int SetVLOGLevel(absl::string_view module_pattern, int log_level) {
     }
   }
   if (!found) {
-    VModuleInfo* info = new VModuleInfo;
+    VModuleInfo *info = new VModuleInfo;
     info->module_pattern = std::string(module_pattern);
 #ifdef _WIN32
     info->module_is_path =
@@ -125,8 +127,8 @@ int SetVLOGLevel(absl::string_view module_pattern, int log_level) {
 
   if (RDSS_VLOG_IS_ON(1)) {
     ABSL_RAW_LOG(INFO, "Set VLOG level for \"%.*s\" to %d",
-            static_cast<int>(module_pattern.size()), module_pattern.data(),
-            log_level);
+                 static_cast<int>(module_pattern.size()), module_pattern.data(),
+                 log_level);
   }
   return result;
 }
@@ -135,7 +137,7 @@ namespace logging_internal {
 
 // NOTE: Individual RDSS_VLOG statements cache the integer log level pointers.
 // NOTE: This function must not allocate memory or require any locks.
-int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path) {
+int InitVLOG(std::atomic<int32_t> *site, absl::string_view full_path) {
   // protect the errno global in case someone writes:
   // RDSS_VLOG(..) << "The last error was " << strerror(errno)
   ErrnoSaver errno_saver_;
@@ -149,7 +151,8 @@ int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path) {
 #ifdef _WIN32
     } else {
       const size_t sep = basename.rfind('\\');
-      if (sep != basename.npos) basename.remove_prefix(sep + 1);
+      if (sep != basename.npos)
+        basename.remove_prefix(sep + 1);
 #endif
     }
   }
@@ -177,7 +180,7 @@ int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path) {
 
   // Find target in list of modules, and set new_site with a
   // module-specific verbosity level, if found.
-  const VModuleInfo* info = vmodule_list.load(std::memory_order_acquire);
+  const VModuleInfo *info = vmodule_list.load(std::memory_order_acquire);
 
   // If we find a matching module in the list, we use its `vlog_level` to
   // control the `VLOG` at the call site. Otherwise, the site remains set to its
@@ -191,7 +194,7 @@ int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path) {
         break;
       }
     } else if (rdss::logging_internal::SafeFNMatch(info->module_pattern,
-                                                  stem_basename)) {
+                                                   stem_basename)) {
       // Otherwise, just match the basename.
       new_site =
           Site(info->vlog_level.load(std::memory_order_acquire), global_epoch);
@@ -209,7 +212,7 @@ int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path) {
   return SiteLevel(new_site);
 }
 
-bool VLogEnabledSlow(std::atomic<int32_t>* site, int32_t level,
+bool VLogEnabledSlow(std::atomic<int32_t> *site, int32_t level,
                      absl::string_view file) {
   const int32_t site_copy = site->load(std::memory_order_acquire);
   int32_t site_level = ABSL_PREDICT_TRUE(SiteEpoch(site_copy) == GlobalEpoch())
@@ -223,5 +226,5 @@ bool VLogEnabledSlow(std::atomic<int32_t>* site, int32_t level,
   return ABSL_PREDICT_FALSE(site_level >= level);
 }
 
-}  // namespace logging_internal
-}  // namespace rdss
+} // namespace logging_internal
+} // namespace rdss

--- a/src/logging/vlog_is_on.hpp
+++ b/src/logging/vlog_is_on.hpp
@@ -69,13 +69,13 @@ ABSL_DECLARE_FLAG(std::string, vmodule);
 // list. This list is mutated through calls to SetVLOGLevel() and
 // mutations to the --vmodule flag. New log sites are initialized
 // with a stale epoch and a verbosity level of kUseFlag.
-#define RDSS_VLOG_IS_ON(verbose_level)               \
-  (::rdss::logging_internal::VLogEnabled(            \
-      []() -> std::atomic<int32_t>* {                \
-        static std::atomic<int32_t> site__(          \
-            ::rdss::logging_internal::kDefaultSite); \
-        return &site__;                              \
-      }(),                                           \
+#define RDSS_VLOG_IS_ON(verbose_level)                                         \
+  (::rdss::logging_internal::VLogEnabled(                                      \
+      []() -> std::atomic<int32_t> * {                                         \
+        static std::atomic<int32_t> site__(                                    \
+            ::rdss::logging_internal::kDefaultSite);                           \
+        return &site__;                                                        \
+      }(),                                                                     \
       (verbose_level), __FILE__))
 
 namespace rdss {
@@ -122,10 +122,10 @@ inline int SiteLevel(int32_t site) { return site >> 16; }
 // or fails.
 //   site: The address of the log site's state.
 //   fname: The filename of the current source file.
-int InitVLOG(std::atomic<int32_t>* site, absl::string_view full_path);
+int InitVLOG(std::atomic<int32_t> *site, absl::string_view full_path);
 
 // Slow path version of VLogEnabled.
-bool VLogEnabledSlow(std::atomic<int32_t>* site, int32_t level,
+bool VLogEnabledSlow(std::atomic<int32_t> *site, int32_t level,
                      absl::string_view file);
 
 // Determine whether verbose logging should occur at a given log site. Fast path
@@ -137,7 +137,7 @@ bool VLogEnabledSlow(std::atomic<int32_t>* site, int32_t level,
 #if defined(__GNUC__) && !defined(__clang__)
 ABSL_ATTRIBUTE_ALWAYS_INLINE
 #endif
-inline bool VLogEnabled(std::atomic<int32_t>* site, int32_t level,
+inline bool VLogEnabled(std::atomic<int32_t> *site, int32_t level,
                         absl::string_view file) {
   const int32_t site_copy = site->load(std::memory_order_acquire);
   if (ABSL_PREDICT_TRUE(SiteEpoch(site_copy) == GlobalEpoch())) {
@@ -153,7 +153,7 @@ inline bool VLogEnabled(std::atomic<int32_t>* site, int32_t level,
   return VLogEnabledSlow(site, level, file);
 }
 
-}  // namespace logging_internal
+} // namespace logging_internal
 
 // Represents a unique callsite for a `RDSS_VLOG()` or `RDSS_VLOG_IS_ON()` call.
 // Helper libraries that provide vlog like functionality should use this to
@@ -163,15 +163,15 @@ inline bool VLogEnabled(std::atomic<int32_t>* site, int32_t level,
 // that in the class would increase the size, so the consistency invariant is
 // pushed onto callers of `IsEnabled()`.
 class VLogSite {
- public:
+public:
   constexpr VLogSite() {}
 
   // Since this is a caching location, copying it doesn't make sense. The copy
   // should get a brand new kDefaultSite.
-  VLogSite(const VLogSite&) = delete;
-  VLogSite& operator=(const VLogSite&) = delete;
-  VLogSite(VLogSite&&) = delete;
-  VLogSite& operator=(VLogSite&&) = delete;
+  VLogSite(const VLogSite &) = delete;
+  VLogSite &operator=(const VLogSite &) = delete;
+  VLogSite(VLogSite &&) = delete;
+  VLogSite &operator=(VLogSite &&) = delete;
 
   // Returns true if logging is enabled. Like RDSS_VLOG_IS_ON(2), this uses
   // internal atomics to be fast in the common case. For any given instance of
@@ -180,16 +180,16 @@ class VLogSite {
     return logging_internal::VLogEnabled(&site_, level, file);
   }
 
- private:
+private:
   mutable std::atomic<int32_t> site_{logging_internal::kDefaultSite};
 };
 
-}  // namespace rdss
+} // namespace rdss
 
 namespace base_logging {
 namespace logging_internal {
 bool SafeFNMatch(absl::string_view pattern, absl::string_view str);
-}  // namespace logging_internal
-}  // namespace base_logging
+} // namespace logging_internal
+} // namespace base_logging
 
-#endif  // RDSS_LOGGING_VLOG_IS_ON_H_
+#endif // RDSS_LOGGING_VLOG_IS_ON_H_

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -16,21 +16,25 @@
 #define RDSS_MACROS_H_
 
 #define CONCAT(a, b) CONCAT_INNER(a, b)
-#define CONCAT_INNER(a, b) a ## b
+#define CONCAT_INNER(a, b) a##b
 
-#define ASSIGN_OR_RETURN_HELPER(lhs, rhs, temp) \
-    auto temp = (rhs);                          \
-    if(!temp.ok()) { return temp.status(); }    \
-    lhs = *temp;
+#define ASSIGN_OR_RETURN_HELPER(lhs, rhs, temp)                                \
+  auto temp = (rhs);                                                           \
+  if (!temp.ok()) {                                                            \
+    return temp.status();                                                      \
+  }                                                                            \
+  lhs = *temp;
 
-#define ASSIGN_OR_RETURN(lhs, rhs)                                      \
-    ASSIGN_OR_RETURN_HELPER(lhs, rhs, CONCAT(temporary, __COUNTER__))
+#define ASSIGN_OR_RETURN(lhs, rhs)                                             \
+  ASSIGN_OR_RETURN_HELPER(lhs, rhs, CONCAT(temporary, __COUNTER__))
 
-#define RETURN_IF_ERROR_HELPER(value, temp)     \
-    auto temp = (value);                        \
-    if(!temp.ok()) { return temp; }
+#define RETURN_IF_ERROR_HELPER(value, temp)                                    \
+  auto temp = (value);                                                         \
+  if (!temp.ok()) {                                                            \
+    return temp;                                                               \
+  }
 
-#define RETURN_IF_ERROR(value)                                      \
-    RETURN_IF_ERROR_HELPER(value, CONCAT(temporary, __COUNTER__))
+#define RETURN_IF_ERROR(value)                                                 \
+  RETURN_IF_ERROR_HELPER(value, CONCAT(temporary, __COUNTER__))
 
-#endif  // RDSS_MACROS_H_
+#endif // RDSS_MACROS_H_

--- a/src/rdss.cpp
+++ b/src/rdss.cpp
@@ -28,288 +28,279 @@
 namespace rdss {
 
 void TestGHD() {
-    Hypergraph<int> graph;
+  Hypergraph<int> graph;
 
-    for (int i = 1; i <= 10; i++) {
-        graph.AddVertex(i);
-    }
+  for (int i = 1; i <= 10; i++) {
+    graph.AddVertex(i);
+  }
 
-    auto e1 = graph.AddEdge();
-    graph.AddVertexToEdge(1, e1);
-    graph.AddVertexToEdge(2, e1);
-    graph.AddVertexToEdge(9, e1);
+  auto e1 = graph.AddEdge();
+  graph.AddVertexToEdge(1, e1);
+  graph.AddVertexToEdge(2, e1);
+  graph.AddVertexToEdge(9, e1);
 
-    auto e2 = graph.AddEdge();
-    graph.AddVertexToEdge(2, e2);
-    graph.AddVertexToEdge(3, e2);
-    graph.AddVertexToEdge(10, e2);
+  auto e2 = graph.AddEdge();
+  graph.AddVertexToEdge(2, e2);
+  graph.AddVertexToEdge(3, e2);
+  graph.AddVertexToEdge(10, e2);
 
-    auto e3 = graph.AddEdge();
-    graph.AddVertexToEdge(3, e3);
-    graph.AddVertexToEdge(4, e3);
+  auto e3 = graph.AddEdge();
+  graph.AddVertexToEdge(3, e3);
+  graph.AddVertexToEdge(4, e3);
 
-    auto e4 = graph.AddEdge();
-    graph.AddVertexToEdge(4, e4);
-    graph.AddVertexToEdge(5, e4);
-    graph.AddVertexToEdge(9, e4);
+  auto e4 = graph.AddEdge();
+  graph.AddVertexToEdge(4, e4);
+  graph.AddVertexToEdge(5, e4);
+  graph.AddVertexToEdge(9, e4);
 
-    auto e5 = graph.AddEdge();
-    graph.AddVertexToEdge(5, e5);
-    graph.AddVertexToEdge(6, e5);
-    graph.AddVertexToEdge(10, e5);
+  auto e5 = graph.AddEdge();
+  graph.AddVertexToEdge(5, e5);
+  graph.AddVertexToEdge(6, e5);
+  graph.AddVertexToEdge(10, e5);
 
-    auto e6 = graph.AddEdge();
-    graph.AddVertexToEdge(6, e6);
-    graph.AddVertexToEdge(7, e6);
-    graph.AddVertexToEdge(9, e6);
+  auto e6 = graph.AddEdge();
+  graph.AddVertexToEdge(6, e6);
+  graph.AddVertexToEdge(7, e6);
+  graph.AddVertexToEdge(9, e6);
 
-    auto e7 = graph.AddEdge();
-    graph.AddVertexToEdge(7, e7);
-    graph.AddVertexToEdge(8, e7);
-    graph.AddVertexToEdge(10, e7);
+  auto e7 = graph.AddEdge();
+  graph.AddVertexToEdge(7, e7);
+  graph.AddVertexToEdge(8, e7);
+  graph.AddVertexToEdge(10, e7);
 
-    auto e8 = graph.AddEdge();
-    graph.AddVertexToEdge(1, e8);
-    graph.AddVertexToEdge(8, e8);
+  auto e8 = graph.AddEdge();
+  graph.AddVertexToEdge(1, e8);
+  graph.AddVertexToEdge(8, e8);
 
-    // graph.AddVertex(1);
-    // graph.AddVertex(2);
-    // graph.AddVertex(3);
-    //
-    // auto e1 = graph.AddEdge();
-    // graph.AddVertexToEdge(1, e1);
-    // graph.AddVertexToEdge(2, e1);
-    //
-    // auto e2 = graph.AddEdge();
-    // graph.AddVertexToEdge(2, e2);
-    // graph.AddVertexToEdge(3, e2);
-    //
-    // auto e3 = graph.AddEdge();
-    // graph.AddVertexToEdge(3, e3);
-    // graph.AddVertexToEdge(1, e3);
+  // graph.AddVertex(1);
+  // graph.AddVertex(2);
+  // graph.AddVertex(3);
+  //
+  // auto e1 = graph.AddEdge();
+  // graph.AddVertexToEdge(1, e1);
+  // graph.AddVertexToEdge(2, e1);
+  //
+  // auto e2 = graph.AddEdge();
+  // graph.AddVertexToEdge(2, e2);
+  // graph.AddVertexToEdge(3, e2);
+  //
+  // auto e3 = graph.AddEdge();
+  // graph.AddVertexToEdge(3, e3);
+  // graph.AddVertexToEdge(1, e3);
 
-    absl::StatusOr<FHD<int32_t>> fhd = ComputeFHD(graph);
-    std::cerr << "FHW of graph is: ";
-    if (fhd.ok()) {
-        std::cerr << fhd->fhw << "\n";
-    } else {
-        std::cerr << "unknown\n";
-    }
+  absl::StatusOr<FHD<int32_t>> fhd = ComputeFHD(graph);
+  std::cerr << "FHW of graph is: ";
+  if (fhd.ok()) {
+    std::cerr << fhd->fhw << "\n";
+  } else {
+    std::cerr << "unknown\n";
+  }
 }
 
 absl::Status TestYannakakis() {
-    RelationFactory fac;
-    Tree<Relation*, JoinOn> tree {
-        fac.Make<RelationReference>("A", 2),
-        {
-            { { fac.Make<RelationReference>("B", 2), {} }, {{0, 0}} },
-            { { fac.Make<RelationReference>("C", 2), {} }, {{1, 0}} }
-        }
-    };
+  RelationFactory fac;
+  Tree<Relation *, JoinOn> tree{
+      fac.Make<RelationReference>("A", 2),
+      {{{fac.Make<RelationReference>("B", 2), {}}, {{0, 0}}},
+       {{fac.Make<RelationReference>("C", 2), {}}, {{1, 0}}}}};
 
-    Relation* normal = fac.Make<RelationJoin>(
-        fac.Make<RelationJoin>(fac.Make<RelationReference>("A", 2),
-                               fac.Make<RelationReference>("C", 2),
-                               JoinOn {{1, 0}}),
-        fac.Make<RelationReference>("B", 2),
-        JoinOn {{0, 0}});
-    Relation* yannakakis = Yannakakis(&fac, tree);
+  Relation *normal = fac.Make<RelationJoin>(
+      fac.Make<RelationJoin>(fac.Make<RelationReference>("A", 2),
+                             fac.Make<RelationReference>("C", 2),
+                             JoinOn{{1, 0}}),
+      fac.Make<RelationReference>("B", 2), JoinOn{{0, 0}});
+  Relation *yannakakis = Yannakakis(&fac, tree);
 
-    std::cerr << normal->ToString() << "\n";
-    std::cerr << yannakakis->ToString() << "\n";
+  std::cerr << normal->ToString() << "\n";
+  std::cerr << yannakakis->ToString() << "\n";
 
-    Table a_table(2);
-    Table b_table(2);
-    Table c_table(2);
+  Table a_table(2);
+  Table b_table(2);
+  Table c_table(2);
 
-    RETURN_IF_ERROR(a_table.InsertTuple({100, 5}));
-    RETURN_IF_ERROR(a_table.InsertTuple({101, 6}));
-    RETURN_IF_ERROR(a_table.InsertTuple({102, 7}));
-    RETURN_IF_ERROR(b_table.InsertTuple({101, 500}));
-    RETURN_IF_ERROR(b_table.InsertTuple({102, 501}));
-    RETURN_IF_ERROR(b_table.InsertTuple({103, 502}));
-    RETURN_IF_ERROR(c_table.InsertTuple({5, 800}));
-    RETURN_IF_ERROR(c_table.InsertTuple({5, 801}));
-    RETURN_IF_ERROR(c_table.InsertTuple({7, 802}));
-    RETURN_IF_ERROR(c_table.InsertTuple({7, 803}));
-    RETURN_IF_ERROR(c_table.InsertTuple({8, 804}));
+  RETURN_IF_ERROR(a_table.InsertTuple({100, 5}));
+  RETURN_IF_ERROR(a_table.InsertTuple({101, 6}));
+  RETURN_IF_ERROR(a_table.InsertTuple({102, 7}));
+  RETURN_IF_ERROR(b_table.InsertTuple({101, 500}));
+  RETURN_IF_ERROR(b_table.InsertTuple({102, 501}));
+  RETURN_IF_ERROR(b_table.InsertTuple({103, 502}));
+  RETURN_IF_ERROR(c_table.InsertTuple({5, 800}));
+  RETURN_IF_ERROR(c_table.InsertTuple({5, 801}));
+  RETURN_IF_ERROR(c_table.InsertTuple({7, 802}));
+  RETURN_IF_ERROR(c_table.InsertTuple({7, 803}));
+  RETURN_IF_ERROR(c_table.InsertTuple({8, 804}));
 
-    // 102, 501, 7, 802
-    // 102, 501, 7, 803
+  // 102, 501, 7, 802
+  // 102, 501, 7, 803
 
-    Table result_table(0);
+  Table result_table(0);
 
-    {
-        absl::btree_map<std::string, Table> variables;
-        variables.insert_or_assign("A", a_table);
-        variables.insert_or_assign("B", b_table);
-        variables.insert_or_assign("C", c_table);
+  {
+    absl::btree_map<std::string, Table> variables;
+    variables.insert_or_assign("A", a_table);
+    variables.insert_or_assign("B", b_table);
+    variables.insert_or_assign("C", c_table);
 
-        Interpreter interpreter(variables);
+    Interpreter interpreter(variables);
 
-        RETURN_IF_ERROR(interpreter.Interpret(normal));
-        result_table = interpreter.Lookup(normal).value();
-    }
+    RETURN_IF_ERROR(interpreter.Interpret(normal));
+    result_table = interpreter.Lookup(normal).value();
+  }
 
-    for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
-        std::cerr << "TestYannakakis: normal: ["
-                  << absl::StrJoin(result_table.GetTuple(i), ", ")
-                  << "]\n";
-    }
+  for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
+    std::cerr << "TestYannakakis: normal: ["
+              << absl::StrJoin(result_table.GetTuple(i), ", ") << "]\n";
+  }
 
-    {
-        absl::btree_map<std::string, Table> variables;
-        variables.insert_or_assign("A", a_table);
-        variables.insert_or_assign("B", b_table);
-        variables.insert_or_assign("C", c_table);
+  {
+    absl::btree_map<std::string, Table> variables;
+    variables.insert_or_assign("A", a_table);
+    variables.insert_or_assign("B", b_table);
+    variables.insert_or_assign("C", c_table);
 
-        Interpreter interpreter(variables);
+    Interpreter interpreter(variables);
 
-        RETURN_IF_ERROR(interpreter.Interpret(yannakakis));
-        result_table = interpreter.Lookup(yannakakis).value();
-    }
+    RETURN_IF_ERROR(interpreter.Interpret(yannakakis));
+    result_table = interpreter.Lookup(yannakakis).value();
+  }
 
-    for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
-        std::cerr << "TestYannakakis: yannakakis: ["
-                  << absl::StrJoin(result_table.GetTuple(i), ", ")
-                  << "]\n";
-    }
+  for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
+    std::cerr << "TestYannakakis: yannakakis: ["
+              << absl::StrJoin(result_table.GetTuple(i), ", ") << "]\n";
+  }
 
-    return absl::OkStatus();
+  return absl::OkStatus();
 }
 
 absl::Status TestInterpreter() {
-    RelationFactory fac;
-    auto r = fac.Make<RelationReference>("R", 3);
-    auto s = fac.Make<RelationReference>("S", 2);
+  RelationFactory fac;
+  auto r = fac.Make<RelationReference>("R", 3);
+  auto s = fac.Make<RelationReference>("S", 2);
 
-    Table r_table(3);
-    Table s_table(2);
+  Table r_table(3);
+  Table s_table(2);
 
-    RETURN_IF_ERROR(r_table.InsertTuple({500, 3415, 1000}));
-    RETURN_IF_ERROR(r_table.InsertTuple({501, 2241, 1001}));
-    RETURN_IF_ERROR(r_table.InsertTuple({502, 3401, 1000}));
-    RETURN_IF_ERROR(r_table.InsertTuple({503, 2202, 1002}));
-    RETURN_IF_ERROR(s_table.InsertTuple({1001, 501}));
-    RETURN_IF_ERROR(s_table.InsertTuple({1002, 503}));
+  RETURN_IF_ERROR(r_table.InsertTuple({500, 3415, 1000}));
+  RETURN_IF_ERROR(r_table.InsertTuple({501, 2241, 1001}));
+  RETURN_IF_ERROR(r_table.InsertTuple({502, 3401, 1000}));
+  RETURN_IF_ERROR(r_table.InsertTuple({503, 2202, 1002}));
+  RETURN_IF_ERROR(s_table.InsertTuple({1001, 501}));
+  RETURN_IF_ERROR(s_table.InsertTuple({1002, 503}));
 
-    Table result_table(0);
+  Table result_table(0);
 
-    {
-        absl::btree_map<std::string, Table> variables;
-        variables.insert_or_assign("R", r_table);
-        variables.insert_or_assign("S", s_table);
+  {
+    absl::btree_map<std::string, Table> variables;
+    variables.insert_or_assign("R", r_table);
+    variables.insert_or_assign("S", s_table);
 
-        Interpreter interpreter(variables);
+    Interpreter interpreter(variables);
 
-        JoinOn join_on;
-        join_on.insert({2, 0});
-        auto semijoin = fac.Make<RelationSemijoin>(r, s, join_on);
+    JoinOn join_on;
+    join_on.insert({2, 0});
+    auto semijoin = fac.Make<RelationSemijoin>(r, s, join_on);
 
-        RETURN_IF_ERROR(interpreter.Interpret(semijoin));
-        result_table = interpreter.Lookup(semijoin).value();
-    }
+    RETURN_IF_ERROR(interpreter.Interpret(semijoin));
+    result_table = interpreter.Lookup(semijoin).value();
+  }
 
-    for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
-        std::cerr << "DEBUG: ["
-                  << absl::StrJoin(result_table.GetTuple(i), ", ")
-                  << "]\n";
-    }
+  for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
+    std::cerr << "DEBUG: [" << absl::StrJoin(result_table.GetTuple(i), ", ")
+              << "]\n";
+  }
 
-    std::cerr << "---------\n";
+  std::cerr << "---------\n";
 
-    RETURN_IF_ERROR(s_table.InsertTuple({1002, 504}));
+  RETURN_IF_ERROR(s_table.InsertTuple({1002, 504}));
 
-    {
-        absl::btree_map<std::string, Table> variables;
-        variables.insert_or_assign("R", r_table);
-        variables.insert_or_assign("S", s_table);
+  {
+    absl::btree_map<std::string, Table> variables;
+    variables.insert_or_assign("R", r_table);
+    variables.insert_or_assign("S", s_table);
 
-        Interpreter interpreter(variables);
+    Interpreter interpreter(variables);
 
-        JoinOn join_on;
-        join_on.insert({2, 0});
-        auto join = fac.Make<RelationJoin>(r, s, join_on);
+    JoinOn join_on;
+    join_on.insert({2, 0});
+    auto join = fac.Make<RelationJoin>(r, s, join_on);
 
-        RETURN_IF_ERROR(interpreter.Interpret(join));
-        result_table = interpreter.Lookup(join).value();
-    }
+    RETURN_IF_ERROR(interpreter.Interpret(join));
+    result_table = interpreter.Lookup(join).value();
+  }
 
-    for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
-        std::cerr << "DEBUG: ["
-                  << absl::StrJoin(result_table.GetTuple(i), ", ")
-                  << "]\n";
-    }
+  for (int32_t i = 0; i < result_table.NumberOfTuples(); i++) {
+    std::cerr << "DEBUG: [" << absl::StrJoin(result_table.GetTuple(i), ", ")
+              << "]\n";
+  }
 
-    return absl::OkStatus();
+  return absl::OkStatus();
 }
 
 absl::Status TestCodegen() {
-    RelationFactory fac;
-    auto r = fac.Make<RelationReference>("R", 2);
-    auto s = fac.Make<RelationReference>("S", 1);
+  RelationFactory fac;
+  auto r = fac.Make<RelationReference>("R", 2);
+  auto s = fac.Make<RelationReference>("S", 1);
 
-    JoinOn join_on;
-    join_on.insert({1, 0});
-    auto semijoin = fac.Make<RelationSemijoin>(r, s, join_on);
+  JoinOn join_on;
+  join_on.insert({1, 0});
+  auto semijoin = fac.Make<RelationSemijoin>(r, s, join_on);
 
-    auto rel_union = fac.Make<RelationUnion>(r, semijoin);
+  auto rel_union = fac.Make<RelationUnion>(r, semijoin);
 
-    auto difference = fac.Make<RelationDifference>(rel_union, semijoin);
+  auto difference = fac.Make<RelationDifference>(rel_union, semijoin);
 
-    auto view = fac.Make<RelationView>(Viewed<Relation*>({1, 0}, difference));
+  auto view = fac.Make<RelationView>(Viewed<Relation *>({1, 0}, difference));
 
-    TypingContext typing_context;
+  TypingContext typing_context;
 
-    typing_context[r] = new TypeRow({ new TypeInt, new TypeInt });
-    typing_context[s] = new TypeRow({ new TypeInt });
-    typing_context[semijoin] = new TypeRow({ new TypeInt, new TypeInt });
-    typing_context[rel_union] = new TypeRow({ new TypeInt, new TypeInt });
-    typing_context[difference] = new TypeRow({ new TypeInt, new TypeInt });
-    typing_context[view] = new TypeRow({ new TypeInt, new TypeInt });
+  typing_context[r] = new TypeRow({new TypeInt, new TypeInt});
+  typing_context[s] = new TypeRow({new TypeInt});
+  typing_context[semijoin] = new TypeRow({new TypeInt, new TypeInt});
+  typing_context[rel_union] = new TypeRow({new TypeInt, new TypeInt});
+  typing_context[difference] = new TypeRow({new TypeInt, new TypeInt});
+  typing_context[view] = new TypeRow({new TypeInt, new TypeInt});
 
-    FreshVariableSource source;
+  FreshVariableSource source;
 
-    Codegen codegen("example", &source, typing_context);
+  Codegen codegen("example", &source, typing_context);
 
-    RETURN_IF_ERROR(codegen.Run(view));
+  RETURN_IF_ERROR(codegen.Run(view));
 
-    std::cerr << "DEBUG: codegen: " << codegen.ds.ToCpp(&source) << "\n";
+  std::cerr << "DEBUG: codegen: " << codegen.ds.ToCpp(&source) << "\n";
 
-    return absl::OkStatus();
+  return absl::OkStatus();
 }
 
 absl::Status RealMain() {
-    rdss::DataStructure example("Example");
-    // example.members.push_back(
-    //     Member {
-    //         VarName("foo"),
-    //         absl::make_unique<TypeVector>(absl::make_unique<TypeInt>())
-    //     });
-    rdss::Method method(VarName("example"));
+  rdss::DataStructure example("Example");
+  // example.members.push_back(
+  //     Member {
+  //         VarName("foo"),
+  //         absl::make_unique<TypeVector>(absl::make_unique<TypeInt>())
+  //     });
+  rdss::Method method(VarName("example"));
 
-    method.body.push_back(new ActionGetMember {
-            VarName("foo"), VarName("bar"), VarName("baz")
-        });
-    example.methods.push_back(method);
-    FreshVariableSource source;
-    std::cout << example.ToCpp(&source);
+  method.body.push_back(
+      new ActionGetMember{VarName("foo"), VarName("bar"), VarName("baz")});
+  example.methods.push_back(method);
+  FreshVariableSource source;
+  std::cout << example.ToCpp(&source);
 
-    TestGHD();
-    RETURN_IF_ERROR(TestYannakakis());
-    RETURN_IF_ERROR(TestInterpreter());
-    RETURN_IF_ERROR(TestCodegen());
+  TestGHD();
+  RETURN_IF_ERROR(TestYannakakis());
+  RETURN_IF_ERROR(TestInterpreter());
+  RETURN_IF_ERROR(TestCodegen());
 
-    return absl::OkStatus();
+  return absl::OkStatus();
 }
 
-}  // namespace rdss
+} // namespace rdss
 
 int main() {
-    absl::Status result = rdss::RealMain();
-    if(!result.ok()) {
-        std::cerr << result << "\n";
-        return EXIT_FAILURE;
-    }
-    return EXIT_SUCCESS;
+  absl::Status result = rdss::RealMain();
+  if (!result.ok()) {
+    std::cerr << result << "\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
 }

--- a/src/union_find_map.hpp
+++ b/src/union_find_map.hpp
@@ -31,18 +31,17 @@ namespace rdss {
 //
 // Size is limited to roughly 2^32 elements, so that the offsets can be 32 bits
 // rather than 64.
-template <typename K, typename V>
-class UnionFindMap {
- public:
+template <typename K, typename V> class UnionFindMap {
+public:
   UnionFindMap() = default;
 
   // Insert the given key/value pair.
   //
   // If a value already exists at that key, the value is replaced.
   // `V` must be copyable.
-  void Insert(const K& key, const V& value) {
+  void Insert(const K &key, const V &value) {
     this->Insert(key, value,
-                 [](const V& old_val, const V& new_val) { return new_val; });
+                 [](const V &old_val, const V &new_val) { return new_val; });
   }
 
   // Insert the given key/value pair.
@@ -51,8 +50,7 @@ class UnionFindMap {
   // existing value, if there is one, and should have type compatible with
   // `std::function<V(const V&, const V&)>`. The first argument is the old
   // value, and the second argument is the inserted value.
-  template <typename F>
-  void Insert(const K& key, const V& value, F merge) {
+  template <typename F> void Insert(const K &key, const V &value, F merge) {
     if (key_to_index_.contains(key)) {
       uint32_t index = FindRoot(GetIndex(key).value());
       values_.at(index) = merge(values_.at(index), value);
@@ -68,7 +66,7 @@ class UnionFindMap {
   // Given a key, returns the representative element in that key's equivalence
   // class, along with the associated value. Returns `absl::nullopt` if the
   // given key has never been inserted.
-  absl::optional<std::pair<K, V&>> Find(const K& key) {
+  absl::optional<std::pair<K, V &>> Find(const K &key) {
     if (auto index = GetIndex(key)) {
       uint32_t found = FindRoot(index.value());
       return {{keys_.at(found), values_.at(found)}};
@@ -87,8 +85,7 @@ class UnionFindMap {
   // Note that if two keys are merged, the merged value is stored twice in this
   // data structure, so `V` must be copyable and should be small if space is a
   // concern.
-  template <typename F>
-  bool Union(const K& x, const K& y, F merge) {
+  template <typename F> bool Union(const K &x, const K &y, F merge) {
     absl::optional<uint32_t> x_index = GetIndex(x);
     if (!x_index.has_value()) {
       return false;
@@ -117,21 +114,21 @@ class UnionFindMap {
   }
 
   // Returns true if the iven key was ever inserted.
-  bool Contains(const K& key) const { return key_to_index_.contains(key); }
+  bool Contains(const K &key) const { return key_to_index_.contains(key); }
 
   // Returns every key ever inserted, with unspecified ordering.
-  const std::vector<K>& GetKeys() const { return keys_; }
+  const std::vector<K> &GetKeys() const { return keys_; }
 
   // Returns the smallest element of every equivalence class.
   absl::flat_hash_set<K> GetRepresentatives() {
     absl::flat_hash_set<K> result;
-    for (const K& key : keys_) {
+    for (const K &key : keys_) {
       result.insert(Find(key)->first);
     }
     return result;
   }
 
- private:
+private:
   // The `parent` field should be a valid index into `nodes_` et al.
   // A root node will have itself as its parent.
   struct Node {
@@ -139,7 +136,7 @@ class UnionFindMap {
     uint32_t size;
   };
 
-  absl::optional<uint32_t> GetIndex(const K& key) {
+  absl::optional<uint32_t> GetIndex(const K &key) {
     if (!key_to_index_.contains(key)) {
       return absl::nullopt;
     }
@@ -174,6 +171,6 @@ class UnionFindMap {
   std::vector<Node> nodes_;
 };
 
-}  // namespace rdss
+} // namespace rdss
 
-#endif  // RDSS_UNION_FIND_MAP_H_
+#endif // RDSS_UNION_FIND_MAP_H_

--- a/test/fhd_tests.cpp
+++ b/test/fhd_tests.cpp
@@ -1,102 +1,97 @@
-#include <string>
-#include <vector>
-#include <gtest/gtest.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 #include <absl/strings/string_view.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
 
 #include "../src/filesystem.hpp"
 #include "../src/ghd.hpp"
 
-absl::optional<rdss::Hypergraph<std::string>>
-ParseHG(absl::string_view input) {
-    rdss::Hypergraph<std::string> graph;
+absl::optional<rdss::Hypergraph<std::string>> ParseHG(absl::string_view input) {
+  rdss::Hypergraph<std::string> graph;
 
-    std::vector<absl::string_view> lines = absl::StrSplit(input, '\n');
+  std::vector<absl::string_view> lines = absl::StrSplit(input, '\n');
 
-    for (const auto& line : lines) {
-        if (line.empty()) { continue; }
-
-        std::vector<absl::string_view> broken_on_open_paren =
-          absl::StrSplit(absl::StripAsciiWhitespace(line), '(');
-        if (broken_on_open_paren.size() != 2) {
-            return absl::nullopt;
-        }
-        std::vector<absl::string_view> broken_on_close_paren =
-          absl::StrSplit(broken_on_open_paren[1], ')');
-        if (broken_on_close_paren.size() != 2) {
-            return absl::nullopt;
-        }
-        std::vector<absl::string_view> vertices_with_whitespace =
-          absl::StrSplit(broken_on_close_paren[0], ',');
-
-        rdss::HyperedgeId e = graph.AddEdge();
-
-        for (const auto& vertex_with_whitespace
-             : vertices_with_whitespace) {
-            absl::string_view vertex =
-              absl::StripAsciiWhitespace(vertex_with_whitespace);
-            graph.AddVertex(std::string(vertex));
-            if (!graph.AddVertexToEdge(std::string(vertex), e)) {
-                return absl::nullopt;
-            }
-        }
+  for (const auto &line : lines) {
+    if (line.empty()) {
+      continue;
     }
 
-    return graph;
-}
-
-void TestGraph(
-    const std::filesystem::path& hg_path,
-    const std::filesystem::path& opt_path
-) {
-     absl::StatusOr<std::string> graph_str = rdss::GetFileContents(hg_path);
-    if (!graph_str.ok()) {
-        std::cerr << graph_str.status();
-        FAIL();
+    std::vector<absl::string_view> broken_on_open_paren =
+        absl::StrSplit(absl::StripAsciiWhitespace(line), '(');
+    if (broken_on_open_paren.size() != 2) {
+      return absl::nullopt;
     }
-    auto parsed_graph = ParseHG(*graph_str);
-    EXPECT_TRUE(parsed_graph.has_value());
-
-    absl::StatusOr<std::string> fhw_result_str = rdss::GetFileContents(opt_path);
-    if (!fhw_result_str.ok()) {
-        std::cerr << fhw_result_str.status();
-        FAIL();
+    std::vector<absl::string_view> broken_on_close_paren =
+        absl::StrSplit(broken_on_open_paren[1], ')');
+    if (broken_on_close_paren.size() != 2) {
+      return absl::nullopt;
     }
-    double fhw_opt;
-    auto parsed_fhw_result = absl::SimpleAtod(fhw_result_str.value(), &fhw_opt);
-    EXPECT_TRUE(parsed_fhw_result);
+    std::vector<absl::string_view> vertices_with_whitespace =
+        absl::StrSplit(broken_on_close_paren[0], ',');
 
-    auto computed_fhw = rdss::ComputeFHD(parsed_graph.value());
-    EXPECT_TRUE(computed_fhw.ok());
-    EXPECT_EQ(computed_fhw->fhw, fhw_opt);
+    rdss::HyperedgeId e = graph.AddEdge();
 
+    for (const auto &vertex_with_whitespace : vertices_with_whitespace) {
+      absl::string_view vertex =
+          absl::StripAsciiWhitespace(vertex_with_whitespace);
+      graph.AddVertex(std::string(vertex));
+      if (!graph.AddVertexToEdge(std::string(vertex), e)) {
+        return absl::nullopt;
+      }
+    }
+  }
+
+  return graph;
 }
 
-TEST(FHD, c4) {
-    TestGraph("../test/graphs/c4.hg", "../test/graphs/c4.opt");
+void TestGraph(const std::filesystem::path &hg_path,
+               const std::filesystem::path &opt_path) {
+  absl::StatusOr<std::string> graph_str = rdss::GetFileContents(hg_path);
+  if (!graph_str.ok()) {
+    std::cerr << graph_str.status();
+    FAIL();
+  }
+  auto parsed_graph = ParseHG(*graph_str);
+  EXPECT_TRUE(parsed_graph.has_value());
+
+  absl::StatusOr<std::string> fhw_result_str = rdss::GetFileContents(opt_path);
+  if (!fhw_result_str.ok()) {
+    std::cerr << fhw_result_str.status();
+    FAIL();
+  }
+  double fhw_opt;
+  auto parsed_fhw_result = absl::SimpleAtod(fhw_result_str.value(), &fhw_opt);
+  EXPECT_TRUE(parsed_fhw_result);
+
+  auto computed_fhw = rdss::ComputeFHD(parsed_graph.value());
+  EXPECT_TRUE(computed_fhw.ok());
+  EXPECT_EQ(computed_fhw->fhw, fhw_opt);
 }
+
+TEST(FHD, c4) { TestGraph("../test/graphs/c4.hg", "../test/graphs/c4.opt"); }
 
 TEST(FHD, triangle) {
-    TestGraph("../test/graphs/triangle.hg", "../test/graphs/triangle.opt");
+  TestGraph("../test/graphs/triangle.hg", "../test/graphs/triangle.opt");
 }
 
 TEST(FHD, imdb_q13a) {
-    TestGraph("../test/graphs/imdb-q13a.hg", "../test/graphs/imdb-q13a.opt");
+  TestGraph("../test/graphs/imdb-q13a.hg", "../test/graphs/imdb-q13a.opt");
 }
 
 TEST(FHD, tpch_manual_q10_min) {
-    TestGraph("../test/graphs/tpch-manual-q10-min.hg",
-              "../test/graphs/tpch-manual-q10-min.opt");
+  TestGraph("../test/graphs/tpch-manual-q10-min.hg",
+            "../test/graphs/tpch-manual-q10-min.opt");
 }
 
 TEST(FHD, tpch_manual_q10) {
-    TestGraph("../test/graphs/tpch-manual-q10.hg",
-              "../test/graphs/tpch-manual-q10.opt");
+  TestGraph("../test/graphs/tpch-manual-q10.hg",
+            "../test/graphs/tpch-manual-q10.opt");
 }
 
 TEST(FHD, tpch_synthetic_q5) {
-    TestGraph("../test/graphs/tpch-synthetic-q5.hg",
-              "../test/graphs/tpch-synthetic-q5.opt");
+  TestGraph("../test/graphs/tpch-synthetic-q5.hg",
+            "../test/graphs/tpch-synthetic-q5.opt");
 }


### PR DESCRIPTION
also adds make rule `clangformat` so that we can run `make clangformat` whenever

resolves #2